### PR TITLE
docs: 标记 P0 阶段已完成，同步 PRD.md

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -867,16 +867,16 @@ zhenduanqi/
 
 ## Implementation Phasing
 
-### 第一阶段（P0）：安全基础设施
+### 第一阶段（P0）：安全基础设施 ✅ 已完成
 目标：具备完整的认证、权限、审计安全能力
-- 认证模块：登录/登出/JWT + HttpOnly Cookie
-- RBAC 权限：拦截器 + @RequireRole 注解 + 用户/角色管理
-- 审计日志：AOP @AuditLog 注解 + 审计日志查询页面
-- 高危命令拦截：修订后的黑名单（ognl/mc/redefine/retransform/heapdump）+ 系统命令豁免
-- 应用运行时日志：logback-spring.xml 配置 + MDC 请求链路追踪 + 敏感字段脱敏 + 各组件日志埋点
-- ArthasHttpClient 改造：Jackson 解析 Arthas JSON 响应，透传结构化数据
-- 现有服务器管理 + 命令执行接口增加权限校验
-- 前端登录页 + 路由守卫 + 角色按钮控制
+- ✅ 认证模块：登录/登出/JWT + HttpOnly Cookie
+- ✅ RBAC 权限：拦截器 + @RequireRole 注解 + 用户/角色管理
+- ✅ 审计日志：AOP @AuditLog 注解 + 审计日志查询页面
+- ✅ 高危命令拦截：修订后的黑名单（ognl/mc/redefine/retransform/heapdump）+ 系统命令豁免
+- ✅ 应用运行时日志：logback-spring.xml 配置 + MDC 请求链路追踪 + 敏感字段脱敏 + 各组件日志埋点
+- ✅ ArthasHttpClient 改造：Jackson 解析 Arthas JSON 响应，透传结构化数据
+- ✅ 现有服务器管理 + 命令执行接口增加权限校验
+- ✅ 前端登录页 + 路由守卫 + 角色按钮控制
 
 ### 第二阶段（P1）：场景模板引擎 — 基础版
 目标：实现一次性命令场景的诊断向导


### PR DESCRIPTION
## 改动内容

标记 PRD.md 中 P0（安全基础设施）阶段为已完成状态，所有子项添加 ✅ 标记。

P0 阶段所有功能已实现并通过测试：
- 认证模块（JWT + HttpOnly Cookie）
- RBAC 权限（拦截器 + @RequireRole）
- 审计日志（AOP @AuditLog）
- 高危命令拦截（5 条黑名单 + 系统命令豁免）
- 运行时日志（logback + MDC + 脱敏 + 埋点）
- ArthasHttpClient Jackson 改造
- 服务器管理 + 命令执行权限校验
- 前端登录页 + 路由守卫 + 角色控制