### PR TITLE
[P0] ArthasHttpClient Jackson 改造：结构化 JSON 解析 (#24)

### DIFF
--- a/src/main/java/com/zhenduanqi/client/ArthasHttpClient.java
+++ b/src/main/java/com/zhenduanqi/client/ArthasHttpClient.java
@@ -1,6 +1,9 @@
 package com.zhenduanqi.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zhenduanqi.model.ArthasApiResponse;
 import com.zhenduanqi.model.ArthasResponse;
+import com.zhenduanqi.model.ArthasResult;
 import com.zhenduanqi.model.ServerInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,19 +14,26 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class ArthasHttpClient {
 
     private static final Logger log = LoggerFactory.getLogger(ArthasHttpClient.class);
     private static final Duration TIMEOUT = Duration.ofSeconds(60);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final HttpClient httpClient;
 
     public ArthasHttpClient() {
-        this.httpClient = HttpClient.newBuilder()
+        this(HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
-                .build();
+                .build());
+    }
+
+    public ArthasHttpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
     }
 
     public ArthasResponse executeCommand(ServerInfo server, String command) {
@@ -44,25 +54,21 @@ public class ArthasHttpClient {
             log.info("Executing command on {}: {}", server.getName(), command);
             HttpResponse<String> httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
+            String body = httpResponse.body();
+            response.setRawResponse(body);
+            log.debug("Arthas raw response: {}", body);
+
             if (httpResponse.statusCode() != 200) {
                 response.setState("failed");
-                String errorBody = httpResponse.body();
-                String errorMessage = errorBody != null && !errorBody.isEmpty() 
-                        ? errorBody 
+                String errorMessage = body != null && !body.isEmpty() 
+                        ? body 
                         : getHttpErrorMessage(httpResponse.statusCode());
                 response.setError("HTTP " + httpResponse.statusCode() + ": " + errorMessage);
-                response.setRawResponse(errorBody != null && !errorBody.isEmpty() 
-                        ? errorBody 
-                        : "HTTP " + httpResponse.statusCode() + ": " + errorMessage);
-                log.error("Arthas API returned status {}: {}", httpResponse.statusCode(), errorBody);
+                log.error("Arthas API returned status {}: {}", httpResponse.statusCode(), body);
                 return response;
             }
 
-            String body = httpResponse.body();
-            log.debug("Arthas raw response: {}", body);
-
-            parseStreamingResponse(body, response);
-            response.setRawResponse(body);
+            parseResponseWithJackson(body, response);
 
         } catch (java.net.ConnectException e) {
             response.setState("failed");
@@ -87,145 +93,42 @@ public class ArthasHttpClient {
         return response;
     }
 
-    private void parseStreamingResponse(String body, ArthasResponse response) {
-        String[] lines = body.split("\n");
-        StringBuilder resultBuilder = new StringBuilder();
-
-        for (String line : lines) {
-            line = line.trim();
-            if (line.isEmpty()) {
-                continue;
-            }
-
-            try {
-                if (line.contains("\"type\":\"status\"")) {
-                    String status = extractJsonValue(line, "content");
-                    if (status != null) {
-                        response.setState(status);
-                    }
-                } else if (line.contains("\"type\":\"result\"")) {
-                    String content = extractResultContent(line);
-                    if (content != null && !content.isEmpty()) {
-                        if (resultBuilder.length() > 0) {
-                            resultBuilder.append("\n");
-                        }
-                        resultBuilder.append(content);
-                    }
-                }
-            } catch (Exception e) {
-                log.warn("Failed to parse response line: {}", line, e);
-            }
-        }
-
-        if (resultBuilder.length() > 0) {
-            response.getResults().add(resultBuilder.toString());
-        }
-
-        if (response.getState() == null) {
-            if (body.contains("\"success\":true") || body.contains("succeeded")) {
-                response.setState("succeeded");
-            } else if (body.contains("\"success\":false") || body.contains("failed")) {
-                response.setState("failed");
-                response.setError(body);
-            } else {
-                response.setState("succeeded");
-                response.getResults().add(body);
-            }
-        }
-    }
-
-    private String extractResultContent(String jsonLine) {
+    private void parseResponseWithJackson(String body, ArthasResponse response) {
         try {
-            int contentStart = jsonLine.indexOf("\"content\":");
-            if (contentStart < 0) {
-                return null;
-            }
-
-            String afterContent = jsonLine.substring(contentStart + "\"content\":".length());
-            String trimmed = afterContent.trim();
-
-            if (trimmed.startsWith("\"")) {
-                if (trimmed.length() > 1) {
-                    int endQuote = trimmed.indexOf("\"", 1);
-                    if (endQuote > 0) {
-                        return trimmed.substring(1, endQuote);
-                    }
-                    return trimmed.substring(1);
-                }
-                return "";
-            }
-
-            if (trimmed.startsWith("{")) {
-                int braceDepth = 0;
-                int contentObjEnd = -1;
-                for (int i = 0; i < trimmed.length(); i++) {
-                    char c = trimmed.charAt(i);
-                    if (c == '{') {
-                        braceDepth++;
-                    } else if (c == '}') {
-                        braceDepth--;
-                        if (braceDepth == 0) {
-                            contentObjEnd = i + 1;
-                            break;
-                        }
+            ArthasApiResponse apiResponse = objectMapper.readValue(body, ArthasApiResponse.class);
+            
+            response.setState(apiResponse.getState());
+            
+            if (apiResponse.getBody() != null && apiResponse.getBody().getResults() != null) {
+                response.setStructuredResults(apiResponse.getBody().getResults());
+                
+                List<String> textResults = new ArrayList<>();
+                for (ArthasResult result : apiResponse.getBody().getResults()) {
+                    try {
+                        textResults.add(objectMapper.writeValueAsString(result));
+                    } catch (Exception e) {
+                        log.warn("Failed to serialize result to string", e);
                     }
                 }
-                if (contentObjEnd > 0) {
-                    String contentObj = trimmed.substring(0, contentObjEnd);
-                    String resultValue = extractJsonValue(contentObj, "result");
-                    if (resultValue != null) {
-                        return resultValue;
-                    }
-                    return contentObj;
-                }
+                response.setResults(textResults);
             }
-
-            return trimmed;
+            
         } catch (Exception e) {
-            log.warn("Failed to extract result content from: {}", jsonLine, e);
-            return null;
+            log.warn("Failed to parse structured JSON, falling back to raw text", e);
+            fallbackToRawText(body, response);
         }
     }
 
-    private String extractJsonValue(String json, String key) {
-        String searchKey = "\"" + key + "\":";
-        int keyStart = json.indexOf(searchKey);
-        if (keyStart < 0) {
-            return null;
-        }
-
-        int valueStart = keyStart + searchKey.length();
-        String afterKey = json.substring(valueStart).trim();
-
-        if (afterKey.startsWith("\"")) {
-            int endQuote = afterKey.indexOf("\"", 1);
-            if (endQuote > 0) {
-                return afterKey.substring(1, endQuote);
-            }
-            return afterKey.substring(1);
-        }
-
-        if (afterKey.startsWith("true")) {
-            return "true";
-        }
-        if (afterKey.startsWith("false")) {
-            return "false";
-        }
-
-        int commaIndex = afterKey.indexOf(",");
-        int braceIndex = afterKey.indexOf("}");
-        int endIndex;
-        if (commaIndex > 0 && braceIndex > 0) {
-            endIndex = Math.min(commaIndex, braceIndex);
-        } else if (commaIndex > 0) {
-            endIndex = commaIndex;
-        } else if (braceIndex > 0) {
-            endIndex = braceIndex;
+    private void fallbackToRawText(String body, ArthasResponse response) {
+        if (body.contains("\"success\":true") || body.contains("succeeded") || body.contains("SUCCEEDED")) {
+            response.setState("succeeded");
+        } else if (body.contains("\"success\":false") || body.contains("failed") || body.contains("FAILED")) {
+            response.setState("failed");
+            response.setError(body);
         } else {
-            endIndex = afterKey.length();
+            response.setState("succeeded");
         }
-
-        return afterKey.substring(0, endIndex).trim();
+        response.getResults().add(body);
     }
 
     private String escapeJson(String input) {

--- a/src/main/java/com/zhenduanqi/dto/ExecuteResponse.java
+++ b/src/main/java/com/zhenduanqi/dto/ExecuteResponse.java
@@ -1,12 +1,14 @@
 package com.zhenduanqi.dto;
 
 import com.zhenduanqi.model.ArthasResponse;
+import com.zhenduanqi.model.ArthasResult;
 import java.util.List;
 
 public class ExecuteResponse {
 
     private String state;
     private List<String> results;
+    private List<ArthasResult> structuredResults;
     private String error;
     private String rawResponse;
 
@@ -14,6 +16,7 @@ public class ExecuteResponse {
         ExecuteResponse resp = new ExecuteResponse();
         resp.setState(arthasResponse.getState());
         resp.setResults(arthasResponse.getResults());
+        resp.setStructuredResults(arthasResponse.getStructuredResults());
         resp.setError(arthasResponse.getError());
         resp.setRawResponse(arthasResponse.getRawResponse());
         return resp;
@@ -35,6 +38,14 @@ public class ExecuteResponse {
         this.results = results;
     }
 
+    public List<ArthasResult> getStructuredResults() {
+        return structuredResults;
+    }
+
+    public void setStructuredResults(List<ArthasResult> structuredResults) {
+        this.structuredResults = structuredResults;
+    }
+
     public String getError() {
         return error;
     }
@@ -54,6 +65,7 @@ public class ExecuteResponse {
     @Override
     public String toString() {
         return "ExecuteResponse{state='" + state + "', results=" + results
+                + ", structuredResults=" + structuredResults
                 + ", error='" + error + "', rawResponse='" + rawResponse + "'}";
     }
 }

--- a/src/main/java/com/zhenduanqi/model/ArthasApiResponse.java
+++ b/src/main/java/com/zhenduanqi/model/ArthasApiResponse.java
@@ -1,0 +1,69 @@
+package com.zhenduanqi.model;
+
+import java.util.List;
+
+public class ArthasApiResponse {
+    private String state;
+    private String sessionId;
+    private String consumerId;
+    private Body body;
+    private String rawResponse;
+
+    public ArthasApiResponse() {
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public void setConsumerId(String consumerId) {
+        this.consumerId = consumerId;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+
+    public void setBody(Body body) {
+        this.body = body;
+    }
+
+    public String getRawResponse() {
+        return rawResponse;
+    }
+
+    public void setRawResponse(String rawResponse) {
+        this.rawResponse = rawResponse;
+    }
+
+    public static class Body {
+        private List<ArthasResult> results;
+
+        public Body() {
+        }
+
+        public List<ArthasResult> getResults() {
+            return results;
+        }
+
+        public void setResults(List<ArthasResult> results) {
+            this.results = results;
+        }
+    }
+}

--- a/src/main/java/com/zhenduanqi/model/ArthasResponse.java
+++ b/src/main/java/com/zhenduanqi/model/ArthasResponse.java
@@ -7,6 +7,7 @@ public class ArthasResponse {
 
     private String state;
     private List<String> results = new ArrayList<>();
+    private List<ArthasResult> structuredResults = new ArrayList<>();
     private String error;
     private String rawResponse;
 
@@ -26,6 +27,14 @@ public class ArthasResponse {
         this.results = results;
     }
 
+    public List<ArthasResult> getStructuredResults() {
+        return structuredResults;
+    }
+
+    public void setStructuredResults(List<ArthasResult> structuredResults) {
+        this.structuredResults = structuredResults;
+    }
+
     public String getError() {
         return error;
     }
@@ -43,6 +52,6 @@ public class ArthasResponse {
     }
 
     public boolean isSuccess() {
-        return "succeeded".equals(state);
+        return "succeeded".equalsIgnoreCase(state) || "SUCCEEDED".equals(state);
     }
 }

--- a/src/main/java/com/zhenduanqi/model/ArthasResult.java
+++ b/src/main/java/com/zhenduanqi/model/ArthasResult.java
@@ -1,0 +1,32 @@
+package com.zhenduanqi.model;
+
+import java.util.Map;
+
+public class ArthasResult {
+    private String type;
+    private Map<String, Object> data;
+
+    public ArthasResult() {
+    }
+
+    public ArthasResult(String type, Map<String, Object> data) {
+        this.type = type;
+        this.data = data;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    public void setData(Map<String, Object> data) {
+        this.data = data;
+    }
+}

--- a/src/test/java/com/zhenduanqi/client/ArthasHttpClientTest.java
+++ b/src/test/java/com/zhenduanqi/client/ArthasHttpClientTest.java
@@ -1,0 +1,294 @@
+package com.zhenduanqi.client;
+
+import com.zhenduanqi.model.ArthasResponse;
+import com.zhenduanqi.model.ArthasResult;
+import com.zhenduanqi.model.ServerInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArthasHttpClientTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<String> httpResponse;
+
+    private ArthasHttpClient arthasHttpClient;
+
+    @BeforeEach
+    void setUp() {
+        arthasHttpClient = new ArthasHttpClient(httpClient);
+    }
+
+    private ServerInfo createTestServer() {
+        ServerInfo server = new ServerInfo();
+        server.setId("server1");
+        server.setName("Test Server");
+        server.setHost("localhost");
+        server.setHttpPort(8563);
+        server.setToken("test-token");
+        return server;
+    }
+
+    @Test
+    void parseThreadResponse_withStructuredJson_extractsResults() throws Exception {
+        String threadResponse = """
+            {
+              "state": "SUCCEEDED",
+              "sessionId": "test-session",
+              "consumerId": "test-consumer",
+              "body": {
+                "results": [
+                  {
+                    "type": "thread",
+                    "data": {
+                      "threadId": 1,
+                      "threadName": "main",
+                      "threadState": "RUNNABLE",
+                      "cpu": 0.5
+                    }
+                  },
+                  {
+                    "type": "thread",
+                    "data": {
+                      "threadId": 2,
+                      "threadName": "worker",
+                      "threadState": "BLOCKED",
+                      "cpu": 0.2
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(threadResponse);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "thread -n 5");
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getStructuredResults()).isNotEmpty();
+        assertThat(response.getStructuredResults()).hasSize(2);
+        
+        List<ArthasResult> results = response.getStructuredResults();
+        assertThat(results.get(0).getType()).isEqualTo("thread");
+        assertThat(results.get(0).getData()).containsEntry("threadId", 1);
+        assertThat(results.get(1).getData()).containsEntry("threadName", "worker");
+
+        assertThat(response.getRawResponse()).isEqualTo(threadResponse);
+    }
+
+    @Test
+    void parseMemoryResponse_withStructuredJson_extractsResults() throws Exception {
+        String memoryResponse = """
+            {
+              "state": "SUCCEEDED",
+              "sessionId": "test-session",
+              "body": {
+                "results": [
+                  {
+                    "type": "memory",
+                    "data": {
+                      "heap": 1073741824,
+                      "used": 536870912,
+                      "unit": "bytes"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(memoryResponse);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "memory");
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getStructuredResults()).isNotEmpty();
+        
+        List<ArthasResult> results = response.getStructuredResults();
+        assertThat(results.get(0).getType()).isEqualTo("memory");
+        assertThat(results.get(0).getData()).containsEntry("heap", 1073741824);
+    }
+
+    @Test
+    void parseStatusResponse_withSuccessStatus_setsCorrectState() throws Exception {
+        String statusResponse = """
+            {
+              "state": "SUCCEEDED",
+              "body": {
+                "results": [
+                  {
+                    "type": "status",
+                    "data": {
+                      "status": "true",
+                      "message": "OK"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(statusResponse);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "version");
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+    }
+
+    @Test
+    void parseEnhancerResponse_withEnhancerType_extractsResults() throws Exception {
+        String enhancerResponse = """
+            {
+              "state": "SUCCEEDED",
+              "body": {
+                "results": [
+                  {
+                    "type": "enhancer",
+                    "data": {
+                      "success": true,
+                      "classCount": 2,
+                      "methodCount": 5
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(enhancerResponse);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "watch *.* {*} -n 5");
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getStructuredResults()).isNotEmpty();
+        
+        List<ArthasResult> results = response.getStructuredResults();
+        assertThat(results.get(0).getType()).isEqualTo("enhancer");
+        assertThat(results.get(0).getData()).containsEntry("success", true);
+    }
+
+    @Test
+    void parseUnknownTypeResponse_fallsBackToRawText() throws Exception {
+        String unknownResponse = """
+            {
+              "state": "SUCCEEDED",
+              "body": {
+                "results": [
+                  {
+                    "type": "custom",
+                    "data": {
+                      "field1": "value1",
+                      "field2": "value2"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(unknownResponse);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "custom-command");
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getStructuredResults()).isNotEmpty();
+        assertThat(response.getResults()).isNotEmpty();
+    }
+
+    @Test
+    void parseMalformedJson_returnsRawResponseWithoutException() throws Exception {
+        String malformedJson = "This is not valid JSON at all";
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(malformedJson);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "thread");
+
+        assertThat(response.getState()).isEqualTo("succeeded");
+        assertThat(response.getRawResponse()).isEqualTo(malformedJson);
+    }
+
+    @Test
+    void httpError_returnsFailedState() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(500);
+        when(httpResponse.body()).thenReturn("Internal Server Error");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "thread");
+
+        assertThat(response.getState()).isEqualTo("failed");
+        assertThat(response.getError()).contains("500");
+    }
+
+    @Test
+    void backwardCompatible_withLegacyTextResponse_works() throws Exception {
+        String legacyResponse = """
+            {
+              "state": "SUCCEEDED",
+              "body": {
+                "results": [
+                  {
+                    "type": "command",
+                    "data": {
+                      "content": "thread information here"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn(legacyResponse);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(httpResponse);
+
+        ServerInfo server = createTestServer();
+        ArthasResponse response = arthasHttpClient.executeCommand(server, "thread");
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getRawResponse()).isEqualTo(legacyResponse);
+        assertThat(response.getStructuredResults()).isNotEmpty();
+    }
+}

--- a/src/test/java/com/zhenduanqi/client/ArthasJacksonTest.java
+++ b/src/test/java/com/zhenduanqi/client/ArthasJacksonTest.java
@@ -1,0 +1,121 @@
+package com.zhenduanqi.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zhenduanqi.model.ArthasApiResponse;
+import com.zhenduanqi.model.ArthasResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArthasJacksonTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void parseThreadResponse_withStructuredJson_extractsResults() throws Exception {
+        String threadResponse = """
+            {
+              "state": "SUCCEEDED",
+              "sessionId": "test-session",
+              "consumerId": "test-consumer",
+              "body": {
+                "results": [
+                  {
+                    "type": "thread",
+                    "data": {
+                      "threadId": 1,
+                      "threadName": "main",
+                      "threadState": "RUNNABLE",
+                      "cpu": 0.5
+                    }
+                  },
+                  {
+                    "type": "thread",
+                    "data": {
+                      "threadId": 2,
+                      "threadName": "worker",
+                      "threadState": "BLOCKED",
+                      "cpu": 0.2
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        ArthasApiResponse response = objectMapper.readValue(threadResponse, ArthasApiResponse.class);
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getResults()).isNotEmpty();
+        assertThat(response.getBody().getResults()).hasSize(2);
+
+        List<ArthasResult> results = response.getBody().getResults();
+        assertThat(results.get(0).getType()).isEqualTo("thread");
+        assertThat(results.get(0).getData()).containsEntry("threadId", 1);
+        assertThat(results.get(0).getData()).containsEntry("threadName", "main");
+        assertThat(results.get(1).getData()).containsEntry("threadName", "worker");
+    }
+
+    @Test
+    void parseMemoryResponse_withStructuredJson_extractsResults() throws Exception {
+        String memoryResponse = """
+            {
+              "state": "SUCCEEDED",
+              "body": {
+                "results": [
+                  {
+                    "type": "memory",
+                    "data": {
+                      "heap": 1073741824,
+                      "used": 536870912,
+                      "unit": "bytes"
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        ArthasApiResponse response = objectMapper.readValue(memoryResponse, ArthasApiResponse.class);
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getBody().getResults()).isNotEmpty();
+
+        ArthasResult result = response.getBody().getResults().get(0);
+        assertThat(result.getType()).isEqualTo("memory");
+        assertThat(result.getData()).containsEntry("heap", 1073741824);
+    }
+
+    @Test
+    void parseEnhancerResponse_withEnhancerType_extractsResults() throws Exception {
+        String enhancerResponse = """
+            {
+              "state": "SUCCEEDED",
+              "body": {
+                "results": [
+                  {
+                    "type": "enhancer",
+                    "data": {
+                      "success": true,
+                      "classCount": 2,
+                      "methodCount": 5
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        ArthasApiResponse response = objectMapper.readValue(enhancerResponse, ArthasApiResponse.class);
+
+        assertThat(response.getState()).isEqualTo("SUCCEEDED");
+        assertThat(response.getBody().getResults()).isNotEmpty();
+
+        ArthasResult result = response.getBody().getResults().get(0);
+        assertThat(result.getType()).isEqualTo("enhancer");
+        assertThat(result.getData()).containsEntry("success", true);
+    }
+}


### PR DESCRIPTION
## 变更说明

将 ArthasHttpClient 从手动字符串解析改造为使用 Jackson 正确解析 Arthas HTTP API 返回的结构化 JSON。

## 主要改动

1. **新增模型类**
   - `ArthasApiResponse`: Arthas API 响应的完整结构化模型
   - `ArthasResult`: 单个 result 模型（含 type 和 data 字段）

2. **更新现有模型**
   - `ArthasResponse`: 新增 `structuredResults` 字段，保留 `results` 字段用于向后兼容

3. **重构 ArthasHttpClient**
   - 使用 Jackson ObjectMapper 解析 JSON
   - 透传结构化数据给前端
   - 保留降级处理：解析失败时回退到原始文本

4. **更新 DTO**
   - `ExecuteResponse`: 新增 `structuredResults` 字段

5. **测试覆盖**
   - 新增 `ArthasJacksonTest`: 测试 Jackson 解析逻辑
   - 更新 `ArthasHttpClientTest`: 测试完整 HTTP 调用流程

## 测试结果

- 所有 93 个测试通过 ✅
- 编译通过 ✅

## 关联 Issue

Closes #24