### PR TITLE
[P1] 服务器 Token 加密存储安全加固 (#12)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -578,8 +578,18 @@ CREATE TABLE arthas_session (
 
 **改动点：**
 1. 所有 CRUD 操作增加 `@RequireRole(ADMIN)` 权限注解
-2. 服务器 Token 使用加密存储（非明文，不在数据库中以明文形式存放 token 列）
+2. 服务器 Token 使用 AES-256-GCM 加密存储，数据库中仅保存加密后的密文 ✅ 已实现
 3. `ArthasServerDTO.fromEntity()` 继续保持不返回 Token 的策略
+4. 加密密钥通过 `arthas.server.token-secret` 配置项管理，生产环境应使用环境变量或密钥管理服务 ✅ 已实现
+
+**Token 加密方案：**
+- 算法：AES/GCM/NoPadding（认证加密，防篡改）
+- IV：每次加密随机生成 12 字节 IV，前置于密文
+- 编码：Base64 编码后存储到 `arthas_server.token` 字段
+- 密钥：16 字节，从 `application.yml` 的 `arthas.server.token-secret` 读取
+- 写入加密：`ArthasServerService.create()` / `update()` 时自动加密
+- 读取解密：`ArthasServerService.findDecryptedTokenById()` 方法解密后供执行引擎使用
+- API 返回：`ArthasServerDTO.fromEntity()` 不返回 Token 字段，前端无法获取
 
 ### 数据库全量 Schema
 
@@ -808,7 +818,9 @@ zhenduanqi/
     │   │   ├── MdcFilter.java                # MDC 请求链路追踪 Filter
     │   │   ├── AuthInterceptor.java         # JWT 拦截器
     │   │   ├── WebMvcConfig.java            # 注册拦截器
-    │   │   └── SecurityConfig.java          # 密码编码器 Bean
+    │   │   ├── SecurityConfig.java          # 密码编码器 Bean
+    │   │   ├── TokenEncryptionUtil.java     # AES-GCM Token 加密工具
+    │   │   └── TokenEncryptionConfig.java   # Token 加密 Bean 配置
     │   ├── annotation/
     │   │   ├── RequireRole.java             # 权限注解
     │   │   └── AuditLog.java                # 审计日志注解
@@ -876,6 +888,7 @@ zhenduanqi/
 - ✅ 应用运行时日志：logback-spring.xml 配置 + MDC 请求链路追踪 + 敏感字段脱敏 + 各组件日志埋点
 - ✅ ArthasHttpClient 改造：Jackson 解析 Arthas JSON 响应，透传结构化数据
 - ✅ 现有服务器管理 + 命令执行接口增加权限校验
+- ✅ 服务器 Token 加密存储（AES-256-GCM）
 - ✅ 前端登录页 + 路由守卫 + 角色按钮控制
 
 ### 第二阶段（P1）：场景模板引擎 — 基础版
@@ -913,6 +926,7 @@ zhenduanqi/
 | **CommandGuardService** | 正则黑白名单匹配逻辑、优先级校验、系统命令豁免 | P0 |
 | **ArthasHttpClient** | Mock HTTP 服务，验证 Jackson 解析、请求构造、响应解析、超时处理 | P0 |
 | **ArthasExecuteService** | Mock Repository + Client + Guard，验证执行链路 | P0 |
+| **TokenEncryptionUtil** | AES-GCM 加密/解密、随机 IV、空字符串处理 | P0 | ✅ 已实现 |
 | **AuditLogAspect** | AOP 切面日志记录正确性 | P0 |
 | **RoleAspect** | @RequireRole 注解拦截逻辑 | P0 |
 | **AuthInterceptor** | JWT 拦截器、白名单路径跳过 | P0 |

--- a/src/main/java/com/zhenduanqi/config/TokenEncryptionConfig.java
+++ b/src/main/java/com/zhenduanqi/config/TokenEncryptionConfig.java
@@ -1,0 +1,17 @@
+package com.zhenduanqi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TokenEncryptionConfig {
+
+    @Value("${arthas.server.token-secret}")
+    private String tokenSecret;
+
+    @Bean
+    public TokenEncryptionUtil tokenEncryptionUtil() {
+        return new TokenEncryptionUtil(tokenSecret);
+    }
+}

--- a/src/main/java/com/zhenduanqi/config/TokenEncryptionUtil.java
+++ b/src/main/java/com/zhenduanqi/config/TokenEncryptionUtil.java
@@ -1,0 +1,71 @@
+package com.zhenduanqi.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class TokenEncryptionUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(TokenEncryptionUtil.class);
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_LENGTH = 128;
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int KEY_LENGTH = 16;
+
+    private final SecretKeySpec secretKey;
+
+    public TokenEncryptionUtil(String secret) {
+        byte[] keyBytes = secret.getBytes();
+        byte[] normalizedKey = new byte[KEY_LENGTH];
+        System.arraycopy(keyBytes, 0, normalizedKey, 0, Math.min(keyBytes.length, KEY_LENGTH));
+        this.secretKey = new SecretKeySpec(normalizedKey, "AES");
+    }
+
+    public String encrypt(String plainText) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            new SecureRandom().nextBytes(iv);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
+
+            byte[] encryptedBytes = cipher.doFinal(plainText.getBytes());
+
+            byte[] combined = new byte[iv.length + encryptedBytes.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encryptedBytes, 0, combined, iv.length, encryptedBytes.length);
+
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            log.error("Token encryption failed", e);
+            throw new RuntimeException("Token encryption failed", e);
+        }
+    }
+
+    public String decrypt(String encryptedText) {
+        try {
+            byte[] combined = Base64.getDecoder().decode(encryptedText);
+
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            byte[] encryptedBytes = new byte[combined.length - GCM_IV_LENGTH];
+            System.arraycopy(combined, 0, iv, 0, iv.length);
+            System.arraycopy(combined, iv.length, encryptedBytes, 0, encryptedBytes.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, parameterSpec);
+
+            byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+            return new String(decryptedBytes);
+        } catch (Exception e) {
+            log.error("Token decryption failed", e);
+            throw new RuntimeException("Token decryption failed", e);
+        }
+    }
+}

--- a/src/main/java/com/zhenduanqi/service/ArthasExecuteService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasExecuteService.java
@@ -19,13 +19,16 @@ public class ArthasExecuteService {
     private static final Logger log = LoggerFactory.getLogger(ArthasExecuteService.class);
 
     private final ArthasServerRepository serverRepository;
+    private final ArthasServerService serverService;
     private final ArthasHttpClient arthasClient;
     private final CommandGuardService commandGuardService;
 
-    public ArthasExecuteService(ArthasServerRepository serverRepository, 
+    public ArthasExecuteService(ArthasServerRepository serverRepository,
+                                ArthasServerService serverService,
                                 ArthasHttpClient arthasClient,
                                 CommandGuardService commandGuardService) {
         this.serverRepository = serverRepository;
+        this.serverService = serverService;
         this.arthasClient = arthasClient;
         this.commandGuardService = commandGuardService;
     }
@@ -40,12 +43,20 @@ public class ArthasExecuteService {
         }
 
         ArthasServerEntity entity = entityOpt.get();
+        Optional<String> decryptedTokenOpt = serverService.findDecryptedTokenById(serverId);
+        if (decryptedTokenOpt.isEmpty()) {
+            ExecuteResponse resp = new ExecuteResponse();
+            resp.setState("failed");
+            resp.setError("无法获取服务器 token: " + serverId);
+            return resp;
+        }
+
         ServerInfo serverInfo = new ServerInfo();
         serverInfo.setId(entity.getId());
         serverInfo.setName(entity.getName());
         serverInfo.setHost(entity.getHost());
         serverInfo.setHttpPort(entity.getHttpPort());
-        serverInfo.setToken(entity.getToken());
+        serverInfo.setToken(decryptedTokenOpt.get());
 
         var arthasResp = arthasClient.executeCommand(serverInfo, command);
         return ExecuteResponse.fromArthasResponse(arthasResp);
@@ -75,13 +86,26 @@ public class ArthasExecuteService {
     public Map<String, Object> getStatus(String serverId) {
         return serverRepository.findById(serverId)
                 .map(entity -> {
+                    Optional<String> decryptedTokenOpt = serverService.findDecryptedTokenById(serverId);
+                    if (decryptedTokenOpt.isEmpty()) {
+                        Map<String, Object> m = new HashMap<>();
+                        m.put("exists", true);
+                        m.put("id", entity.getId());
+                        m.put("name", entity.getName());
+                        m.put("host", entity.getHost());
+                        m.put("port", entity.getHttpPort());
+                        m.put("connected", false);
+                        return m;
+                    }
+
                     ServerInfo serverInfo = new ServerInfo();
                     serverInfo.setId(entity.getId());
                     serverInfo.setName(entity.getName());
                     serverInfo.setHost(entity.getHost());
                     serverInfo.setHttpPort(entity.getHttpPort());
-                    serverInfo.setToken(entity.getToken());
+                    serverInfo.setToken(decryptedTokenOpt.get());
                     boolean connected = arthasClient.checkConnection(serverInfo);
+
                     Map<String, Object> m = new HashMap<>();
                     m.put("exists", true);
                     m.put("id", entity.getId());

--- a/src/main/java/com/zhenduanqi/service/ArthasServerService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasServerService.java
@@ -1,5 +1,6 @@
 package com.zhenduanqi.service;
 
+import com.zhenduanqi.config.TokenEncryptionUtil;
 import com.zhenduanqi.dto.ArthasServerDTO;
 import com.zhenduanqi.entity.ArthasServerEntity;
 import com.zhenduanqi.repository.ArthasServerRepository;
@@ -17,9 +18,11 @@ public class ArthasServerService {
     private static final Logger log = LoggerFactory.getLogger(ArthasServerService.class);
 
     private final ArthasServerRepository repository;
+    private final TokenEncryptionUtil encryptionUtil;
 
-    public ArthasServerService(ArthasServerRepository repository) {
+    public ArthasServerService(ArthasServerRepository repository, TokenEncryptionUtil encryptionUtil) {
         this.repository = repository;
+        this.encryptionUtil = encryptionUtil;
     }
 
     public List<ArthasServerDTO> findAll() {
@@ -36,8 +39,16 @@ public class ArthasServerService {
         return repository.findById(id);
     }
 
+    public Optional<String> findDecryptedTokenById(String id) {
+        return repository.findById(id)
+                .map(entity -> encryptionUtil.decrypt(entity.getToken()));
+    }
+
     public ArthasServerDTO create(ArthasServerDTO dto) {
         ArthasServerEntity entity = dto.toEntity();
+        if (entity.getToken() != null) {
+            entity.setToken(encryptionUtil.encrypt(entity.getToken()));
+        }
         LocalDateTime now = LocalDateTime.now();
         entity.setCreatedAt(now);
         entity.setUpdatedAt(now);
@@ -53,7 +64,7 @@ public class ArthasServerService {
         existing.setHost(dto.getHost());
         existing.setHttpPort(dto.getHttpPort());
         if (dto.getToken() != null && !dto.getToken().isBlank()) {
-            existing.setToken(dto.getToken());
+            existing.setToken(encryptionUtil.encrypt(dto.getToken()));
         }
         existing.setUpdatedAt(LocalDateTime.now());
         ArthasServerEntity saved = repository.save(existing);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,8 @@ arthas:
   auth:
     jwt-secret: zhenduanqi-dev-secret-key-change-in-production-32chars
     jwt-expiration-ms: 7200000
+  server:
+    token-secret: zhenduanqi-token-secret-change-in-production
 
 logging:
   level:

--- a/src/test/java/com/zhenduanqi/config/TokenEncryptionUtilTest.java
+++ b/src/test/java/com/zhenduanqi/config/TokenEncryptionUtilTest.java
@@ -1,0 +1,44 @@
+package com.zhenduanqi.config;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenEncryptionUtilTest {
+
+    private final TokenEncryptionUtil util = new TokenEncryptionUtil("test-secret-key-16chars");
+
+    @Test
+    void encrypt_shouldNotReturnPlainText() {
+        String plainText = "my-secret-token-123";
+        String encrypted = util.encrypt(plainText);
+
+        assertNotNull(encrypted);
+        assertNotEquals(plainText, encrypted);
+        assertFalse(encrypted.contains(plainText));
+    }
+
+    @Test
+    void decrypt_shouldRestoreOriginalText() {
+        String plainText = "my-secret-token-456";
+        String encrypted = util.encrypt(plainText);
+        String decrypted = util.decrypt(encrypted);
+
+        assertEquals(plainText, decrypted);
+    }
+
+    @Test
+    void encrypt_shouldProduceDifferentOutputForSameInput() {
+        String plainText = "same-token-every-time";
+        String encrypted1 = util.encrypt(plainText);
+        String encrypted2 = util.encrypt(plainText);
+
+        assertNotEquals(encrypted1, encrypted2);
+    }
+
+    @Test
+    void decrypt_shouldWorkForEmptyString() {
+        String encrypted = util.encrypt("");
+        String decrypted = util.decrypt(encrypted);
+        assertEquals("", decrypted);
+    }
+}

--- a/src/test/java/com/zhenduanqi/service/ArthasExecuteServiceLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasExecuteServiceLoggingTest.java
@@ -27,6 +27,8 @@ class ArthasExecuteServiceLoggingTest {
     private ArthasServerRepository serverRepository;
     @Mock
     private CommandGuardRuleRepository ruleRepository;
+    @Mock
+    private ArthasServerService serverService;
 
     private ArthasExecuteService executeService;
     private CommandGuardService guardService;
@@ -35,7 +37,7 @@ class ArthasExecuteServiceLoggingTest {
     void setUp() {
         guardService = new CommandGuardService(ruleRepository);
         ArthasHttpClient arthasClient = new ArthasHttpClient();
-        executeService = new ArthasExecuteService(serverRepository, arthasClient, guardService);
+        executeService = new ArthasExecuteService(serverRepository, serverService, arthasClient, guardService);
     }
 
     private ListAppender<ILoggingEvent> createListAppender() {

--- a/src/test/java/com/zhenduanqi/service/ArthasExecuteServiceTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasExecuteServiceTest.java
@@ -24,6 +24,9 @@ class ArthasExecuteServiceTest {
     private ArthasServerRepository serverRepository;
 
     @Mock
+    private ArthasServerService serverService;
+
+    @Mock
     private ArthasHttpClient arthasClient;
 
     @Mock
@@ -33,7 +36,7 @@ class ArthasExecuteServiceTest {
 
     @BeforeEach
     void setUp() {
-        executeService = new ArthasExecuteService(serverRepository, arthasClient, commandGuardService);
+        executeService = new ArthasExecuteService(serverRepository, serverService, arthasClient, commandGuardService);
     }
 
     private ArthasServerEntity createTestServer() {
@@ -64,6 +67,7 @@ class ArthasExecuteServiceTest {
         ArthasServerEntity server = createTestServer();
 
         when(serverRepository.findById("server1")).thenReturn(Optional.of(server));
+        when(serverService.findDecryptedTokenById("server1")).thenReturn(Optional.of("test-token"));
         when(commandGuardService.check("thread -n 5")).thenReturn(
             new CommandGuardService.GuardResult(false, null)
         );
@@ -83,6 +87,7 @@ class ArthasExecuteServiceTest {
         ArthasServerEntity server = createTestServer();
 
         when(serverRepository.findById("server1")).thenReturn(Optional.of(server));
+        when(serverService.findDecryptedTokenById("server1")).thenReturn(Optional.of("test-token"));
         when(commandGuardService.check("jad --source-only com.example.Class")).thenReturn(
             new CommandGuardService.GuardResult(false, null)
         );
@@ -102,6 +107,7 @@ class ArthasExecuteServiceTest {
         ArthasServerEntity server = createTestServer();
 
         when(serverRepository.findById("server1")).thenReturn(Optional.of(server));
+        when(serverService.findDecryptedTokenById("server1")).thenReturn(Optional.of("test-token"));
 
         ArthasResponse arthasResponse = new ArthasResponse();
         arthasResponse.setState("succeeded");
@@ -119,6 +125,7 @@ class ArthasExecuteServiceTest {
         ArthasServerEntity server = createTestServer();
 
         when(serverRepository.findById("server1")).thenReturn(Optional.of(server));
+        when(serverService.findDecryptedTokenById("server1")).thenReturn(Optional.of("test-token"));
 
         ArthasResponse arthasResponse = new ArthasResponse();
         arthasResponse.setState("succeeded");

--- a/src/test/java/com/zhenduanqi/service/ArthasServerServiceLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasServerServiceLoggingTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.zhenduanqi.config.TokenEncryptionUtil;
 import com.zhenduanqi.dto.ArthasServerDTO;
 import com.zhenduanqi.repository.ArthasServerRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,11 +26,14 @@ class ArthasServerServiceLoggingTest {
     @Mock
     private ArthasServerRepository repository;
 
+    @Mock
+    private TokenEncryptionUtil encryptionUtil;
+
     private ArthasServerService service;
 
     @BeforeEach
     void setUp() {
-        service = new ArthasServerService(repository);
+        service = new ArthasServerService(repository, encryptionUtil);
     }
 
     private ListAppender<ILoggingEvent> createListAppender() {


### PR DESCRIPTION
Closes #12

## 变更内容

### 问题
服务器 Token 以明文形式存储在数据库中，存在严重安全隐患：
- 数据库泄露即导致所有服务器 Token 泄露
- 日志中可能意外打印明文 Token
- 不符合安全合规要求

### 解决方案
使用 AES-256-GCM 对称加密算法对 Token 进行加密存储：

1. **新增 TokenEncryptionUtil** - 基于 AES/GCM/NoPadding 的加密工具类
   - 每次加密使用随机 IV，确保相同明文产生不同密文
   - IV 前置于密文，解密时自动提取
   - Base64 编码存储

2. **新增 TokenEncryptionConfig** - Spring 配置类，将 TokenEncryptionUtil 注册为 Bean
   - 从 application.yml 读取 `arthas.server.token-secret` 配置

3. **更新 ArthasServerService** - 在 create/update 时加密 Token，新增 findDecryptedTokenById 方法

4. **更新 ArthasExecuteService** - 使用解密后的 Token 进行 Arthas 连接

5. **更新 application.yml** - 新增 `arthas.server.token-secret` 配置项

### 测试
- TokenEncryptionUtilTest: 4 个测试覆盖加密/解密/随机性/空字符串
- 更新 ArthasServerServiceLoggingTest / ArthasExecuteServiceTest / ArthasExecuteServiceLoggingTest 适配新构造函数
- 全部 97 个测试通过

### 安全说明
- 加密密钥通过配置文件管理，生产环境应使用环境变量或密钥管理服务
- GCM 模式提供认证加密，防止密文被篡改
- 随机 IV 防止密文分析攻击