### PR TITLE
[P0] 添加 Render 免费层自动部署配置

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -591,6 +591,51 @@ CREATE TABLE arthas_session (
 - 读取解密：`ArthasServerService.findDecryptedTokenById()` 方法解密后供执行引擎使用
 - API 返回：`ArthasServerDTO.fromEntity()` 不返回 Token 字段，前端无法获取
 
+### 部署策略 (Render 免费层)
+
+**目标：** PR 合并到 main 后自动部署到 Render 免费层，供调试使用。
+
+**部署平台：** Render (https://render.com)
+
+| 配置项 | 方案 |
+|--------|------|
+| 部署方式 | Render 原生 GitHub 集成，监听 main 分支变更自动部署 |
+| 配置文件 | `render.yaml`（Render Blueprint，版本控制） |
+| 运行计划 | Free（750 小时/月，15 分钟无流量后休眠，冷启动约 30 秒） |
+| 数据库 | H2 内存模式（每次部署/重启后数据重置为 import.sql 初始状态） |
+| Spring Profile | `render`（H2 内存模式、生产级日志、环境变量覆盖敏感配置） |
+
+**`render` Profile 配置要点：**
+
+| 配置项 | 值 | 说明 |
+|--------|-----|------|
+| `spring.datasource.url` | `jdbc:h2:mem:zhenduanqi` | 内存模式，重启后数据清空 |
+| `spring.h2.console.enabled` | `false` | 禁用 H2 控制台，避免公网暴露 |
+| `server.port` | `${PORT:8080}` | Render 通过 PORT 环境变量指定端口 |
+| `arthas.auth.jwt-secret` | `${JWT_SECRET}` | 环境变量注入，Render 自动生成随机值 |
+| `arthas.server.token-secret` | `${TOKEN_SECRET}` | 环境变量注入，Render 自动生成随机值 |
+| 日志级别 | root=WARN, com.zhenduanqi=INFO | 生产级日志，仅控制台输出 |
+
+**Render 环境变量：**
+
+| 变量名 | 来源 | 说明 |
+|--------|------|------|
+| `JWT_SECRET` | Render `generateValue: true` | 自动生成随机密钥 |
+| `TOKEN_SECRET` | Render `generateValue: true` | 自动生成随机密钥 |
+| `JWT_EXPIRATION_MS` | 固定值 `7200000` | Token 有效期 2 小时 |
+| `PORT` | Render 自动注入 | 服务监听端口 |
+
+**部署流程：**
+```
+PR 合并到 main → Render 检测到变更 → mvn package -DskipTests → java -jar target/zhenduanqi-1.0.0.jar --spring.profiles.active=render → 健康检查通过 → 上线
+```
+
+**限制与注意事项：**
+- 免费实例 15 分钟无流量后休眠，首次访问冷启动约 30 秒
+- 每次部署/重启后数据库重置（H2 内存模式）
+- 不适合生产环境使用，仅用于调试
+- 750 小时/月运行时间限制（足够 1 个实例 24/7 运行）
+
 ### 数据库全量 Schema
 
 ```sql
@@ -779,6 +824,7 @@ CREATE TABLE arthas_session (
 zhenduanqi/
 ├── pom.xml
 ├── PRD.md
+├── render.yaml                              # Render Blueprint 部署配置
 ├── frontend/                        # Vue 3 前端
 │   ├── package.json
 │   ├── vite.config.js
@@ -873,6 +919,7 @@ zhenduanqi/
     │       └── ArthasResult.java              # 单个 result 模型（type + data）
     └── resources/
         ├── application.yml
+        ├── application-render.yml             # Render 专用 Profile 配置
         ├── logback-spring.xml
         └── import.sql                         # 初始化数据（admin + 角色 + 默认规则 + 8个预置场景）
 ```

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: web
+    name: zhenduanqi
+    runtime: java
+    plan: free
+    buildCommand: mvn package -DskipTests
+    startCommand: java -jar target/zhenduanqi-1.0.0.jar --spring.profiles.active=render
+    envVars:
+      - key: JWT_SECRET
+        generateValue: true
+      - key: TOKEN_SECRET
+        generateValue: true
+      - key: JWT_EXPIRATION_MS
+        value: "7200000"

--- a/src/main/resources/application-render.yml
+++ b/src/main/resources/application-render.yml
@@ -1,0 +1,35 @@
+server:
+  port: ${PORT:8080}
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:zhenduanqi
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+      continue-on-error: true
+      encoding: UTF-8
+
+arthas:
+  auth:
+    jwt-secret: ${JWT_SECRET}
+    jwt-expiration-ms: ${JWT_EXPIRATION_MS:7200000}
+  server:
+    token-secret: ${TOKEN_SECRET}
+
+logging:
+  level:
+    root: WARN
+    com.zhenduanqi: INFO

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -40,4 +40,11 @@
         <logger name="com.zhenduanqi" level="INFO"/>
     </springProfile>
 
+    <springProfile name="render">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="com.zhenduanqi" level="INFO"/>
+    </springProfile>
+
 </configuration>


### PR DESCRIPTION
## 概述

为项目添加 Render 免费层自动部署配置，PR 合并到 main 后自动部署到 Render 云平台，供调试使用。

## 变更内容

### 新增文件

| 文件 | 说明 |
|------|------|
| `render.yaml` | Render Blueprint 配置，定义免费层 Java Web 服务 |
| `application-render.yml` | Render 专用 Spring Profile（H2 内存模式、环境变量注入密钥） |

### 修改文件

| 文件 | 变更 |
|------|------|
| `logback-spring.xml` | 添加 `render` profile 日志配置（仅控制台、INFO 级别） |
| `PRD.md` | 添加部署策略章节、更新项目结构 |

### 部署方案

| 配置项 | 方案 |
|--------|------|
| 部署平台 | Render 免费层 |
| 触发方式 | main 分支变更自动部署 |
| 数据库 | H2 内存模式（每次部署重置） |
| 密钥管理 | JWT_SECRET / TOKEN_SECRET 由 Render 自动生成 |
| Spring Profile | `render` |

### 部署后手动步骤

1. 注册 Render（https://render.com，用 GitHub 登录）
2. 创建 Web Service，连接本仓库
3. 选择 main 分支，Render 自动识别 render.yaml
4. 首次部署后获取公网 URL

### 注意事项

- 免费实例 15 分钟无流量后休眠，冷启动约 30 秒
- 每次部署/重启后数据库重置为初始状态
- 仅用于调试，不适合生产环境