### PR TITLE
[P0] 为现有 API 增加认证/权限/审计保护 (#7)

### DIFF
--- a/frontend/src/views/Diagnose.vue
+++ b/frontend/src/views/Diagnose.vue
@@ -26,6 +26,7 @@
 
         <el-form-item>
           <el-button
+            v-if="userStore.role === 'OPERATOR' || userStore.role === 'ADMIN'"
             type="primary"
             @click="handleExecute"
             :loading="executing"
@@ -101,9 +102,11 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import { useServerStore } from '../stores/servers';
+import { useUserStore } from '../stores/user';
 import { executeCommand } from '../api';
 
 const store = useServerStore();
+const userStore = useUserStore();
 const result = ref(null);
 const executing = ref(false);
 const expandRaw = ref(false);

--- a/frontend/src/views/ServerList.vue
+++ b/frontend/src/views/ServerList.vue
@@ -9,7 +9,9 @@
       "
     >
       <h3>服务器管理</h3>
-      <el-button type="primary" @click="openDialog()">添加服务器</el-button>
+      <el-button v-if="userStore.role === 'ADMIN'" type="primary" @click="openDialog()"
+        >添加服务器</el-button
+      >
     </div>
 
     <el-table :data="store.list" v-loading="store.loading" stripe style="width: 100%">
@@ -24,7 +26,7 @@
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column label="操作" width="180">
+      <el-table-column v-if="userStore.role === 'ADMIN'" label="操作" width="180">
         <template #default="{ row }">
           <el-button size="small" @click="openDialog(row)">编辑</el-button>
           <el-button size="small" type="danger" @click="handleDelete(row.id)">删除</el-button>
@@ -67,9 +69,11 @@
 import { ref, onMounted, reactive } from 'vue';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import { useServerStore } from '../stores/servers';
+import { useUserStore } from '../stores/user';
 import { createServer, updateServer, deleteServer, getServerStatus } from '../api';
 
 const store = useServerStore();
+const userStore = useUserStore();
 const dialogVisible = ref(false);
 const isEdit = ref(false);
 const saving = ref(false);

--- a/src/main/java/com/zhenduanqi/controller/ArthasExecuteController.java
+++ b/src/main/java/com/zhenduanqi/controller/ArthasExecuteController.java
@@ -1,6 +1,7 @@
 package com.zhenduanqi.controller;
 
 import com.zhenduanqi.annotation.AuditLog;
+import com.zhenduanqi.annotation.RequireRole;
 import com.zhenduanqi.dto.ExecuteRequest;
 import com.zhenduanqi.dto.ExecuteResponse;
 import com.zhenduanqi.service.ArthasExecuteService;
@@ -20,6 +21,7 @@ public class ArthasExecuteController {
     }
 
     @PostMapping("/execute")
+    @RequireRole({"OPERATOR", "ADMIN"})
     @AuditLog(action = "执行诊断命令")
     public ResponseEntity<ExecuteResponse> execute(@RequestBody ExecuteRequest request) {
         ExecuteResponse response = executeService.execute(request.getServerId(), request.getCommand());

--- a/src/main/java/com/zhenduanqi/controller/ArthasServerController.java
+++ b/src/main/java/com/zhenduanqi/controller/ArthasServerController.java
@@ -1,5 +1,7 @@
 package com.zhenduanqi.controller;
 
+import com.zhenduanqi.annotation.AuditLog;
+import com.zhenduanqi.annotation.RequireRole;
 import com.zhenduanqi.dto.ArthasServerDTO;
 import com.zhenduanqi.service.ArthasServerService;
 import org.springframework.http.HttpStatus;
@@ -31,18 +33,24 @@ public class ArthasServerController {
     }
 
     @PostMapping
+    @RequireRole("ADMIN")
+    @AuditLog(action = "创建服务器")
     public ResponseEntity<ArthasServerDTO> create(@RequestBody ArthasServerDTO dto) {
         ArthasServerDTO created = serverService.create(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @PutMapping("/{id}")
+    @RequireRole("ADMIN")
+    @AuditLog(action = "更新服务器")
     public ResponseEntity<ArthasServerDTO> update(@PathVariable String id, @RequestBody ArthasServerDTO dto) {
         ArthasServerDTO updated = serverService.update(id, dto);
         return ResponseEntity.ok(updated);
     }
 
     @DeleteMapping("/{id}")
+    @RequireRole("ADMIN")
+    @AuditLog(action = "删除服务器")
     public ResponseEntity<Void> delete(@PathVariable String id) {
         serverService.delete(id);
         return ResponseEntity.noContent().build();

--- a/src/test/java/com/zhenduanqi/controller/ArthasExecuteControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/ArthasExecuteControllerTest.java
@@ -1,0 +1,162 @@
+package com.zhenduanqi.controller;
+
+import com.zhenduanqi.aspect.RoleAspect;
+import com.zhenduanqi.dto.ExecuteRequest;
+import com.zhenduanqi.dto.ExecuteResponse;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
+import com.zhenduanqi.service.ArthasExecuteService;
+import com.zhenduanqi.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ArthasExecuteController.class)
+@Import(RoleAspect.class)
+@EnableAspectJAutoProxy
+class ArthasExecuteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ArthasExecuteService executeService;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private SysUserRepository userRepository;
+
+    private final Cookie adminCookie = new Cookie("zhenduanqi_token", "admin-jwt");
+    private final Cookie operatorCookie = new Cookie("zhenduanqi_token", "operator-jwt");
+    private final Cookie readonlyCookie = new Cookie("zhenduanqi_token", "readonly-jwt");
+
+    @BeforeEach
+    void setUp() {
+        SysRole adminRole = new SysRole();
+        adminRole.setRoleCode("ADMIN");
+        SysUser adminUser = new SysUser();
+        adminUser.setUsername("admin");
+        adminUser.setRoles(Set.of(adminRole));
+
+        SysRole operatorRole = new SysRole();
+        operatorRole.setRoleCode("OPERATOR");
+        SysUser operatorUser = new SysUser();
+        operatorUser.setUsername("operator");
+        operatorUser.setRoles(Set.of(operatorRole));
+
+        SysRole readonlyRole = new SysRole();
+        readonlyRole.setRoleCode("READONLY");
+        SysUser readonlyUser = new SysUser();
+        readonlyUser.setUsername("readonly");
+        readonlyUser.setRoles(Set.of(readonlyRole));
+
+        when(authService.validateToken("admin-jwt")).thenReturn("admin");
+        when(authService.validateToken("operator-jwt")).thenReturn("operator");
+        when(authService.validateToken("readonly-jwt")).thenReturn("readonly");
+
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByUsername("operator")).thenReturn(Optional.of(operatorUser));
+        when(userRepository.findByUsername("readonly")).thenReturn(Optional.of(readonlyUser));
+    }
+
+    @Test
+    void execute_withAdminAuth_returns200() throws Exception {
+        ExecuteRequest req = new ExecuteRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        ExecuteResponse resp = new ExecuteResponse();
+        resp.setState("succeeded");
+        when(executeService.execute(anyString(), anyString())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/execute")
+                        .cookie(adminCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.state").value("succeeded"));
+    }
+
+    @Test
+    void execute_withOperatorAuth_returns200() throws Exception {
+        ExecuteRequest req = new ExecuteRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        ExecuteResponse resp = new ExecuteResponse();
+        resp.setState("succeeded");
+        when(executeService.execute(anyString(), anyString())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/execute")
+                        .cookie(operatorCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.state").value("succeeded"));
+    }
+
+    @Test
+    void execute_withReadonlyAuth_returns403() throws Exception {
+        ExecuteRequest req = new ExecuteRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        mockMvc.perform(post("/api/execute")
+                        .cookie(readonlyCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void execute_withoutAuth_returns401() throws Exception {
+        ExecuteRequest req = new ExecuteRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        mockMvc.perform(post("/api/execute")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void status_withAdminAuth_returns200() throws Exception {
+        mockMvc.perform(get("/api/servers/server-1/status").cookie(adminCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void status_withOperatorAuth_returns200() throws Exception {
+        mockMvc.perform(get("/api/servers/server-1/status").cookie(operatorCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void status_withReadonlyAuth_returns200() throws Exception {
+        mockMvc.perform(get("/api/servers/server-1/status").cookie(readonlyCookie))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/zhenduanqi/controller/ArthasServerControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/ArthasServerControllerTest.java
@@ -1,0 +1,198 @@
+package com.zhenduanqi.controller;
+
+import com.zhenduanqi.aspect.RoleAspect;
+import com.zhenduanqi.dto.ArthasServerDTO;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
+import com.zhenduanqi.service.ArthasServerService;
+import com.zhenduanqi.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ArthasServerController.class)
+@Import(RoleAspect.class)
+@EnableAspectJAutoProxy
+class ArthasServerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ArthasServerService serverService;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private SysUserRepository userRepository;
+
+    private final Cookie adminCookie = new Cookie("zhenduanqi_token", "admin-jwt");
+    private final Cookie operatorCookie = new Cookie("zhenduanqi_token", "operator-jwt");
+    private final Cookie readonlyCookie = new Cookie("zhenduanqi_token", "readonly-jwt");
+
+    @BeforeEach
+    void setUp() {
+        SysRole adminRole = new SysRole();
+        adminRole.setRoleCode("ADMIN");
+        adminUser = new SysUser();
+        adminUser.setUsername("admin");
+        adminUser.setRoles(Set.of(adminRole));
+
+        SysRole operatorRole = new SysRole();
+        operatorRole.setRoleCode("OPERATOR");
+        operatorUser = new SysUser();
+        operatorUser.setUsername("operator");
+        operatorUser.setRoles(Set.of(operatorRole));
+
+        SysRole readonlyRole = new SysRole();
+        readonlyRole.setRoleCode("READONLY");
+        readonlyUser = new SysUser();
+        readonlyUser.setUsername("readonly");
+        readonlyUser.setRoles(Set.of(readonlyRole));
+
+        when(authService.validateToken("admin-jwt")).thenReturn("admin");
+        when(authService.validateToken("operator-jwt")).thenReturn("operator");
+        when(authService.validateToken("readonly-jwt")).thenReturn("readonly");
+
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByUsername("operator")).thenReturn(Optional.of(operatorUser));
+        when(userRepository.findByUsername("readonly")).thenReturn(Optional.of(readonlyUser));
+    }
+
+    private SysUser adminUser;
+    private SysUser operatorUser;
+    private SysUser readonlyUser;
+
+    @Test
+    void listServers_withAdminAuth_returns200() throws Exception {
+        mockMvc.perform(get("/api/servers").cookie(adminCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void listServers_withOperatorAuth_returns200() throws Exception {
+        mockMvc.perform(get("/api/servers").cookie(operatorCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void listServers_withoutAuth_returns401() throws Exception {
+        mockMvc.perform(get("/api/servers"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void createServer_withAdminAuth_returns201() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-3");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.102");
+        dto.setHttpPort(8563);
+        dto.setToken("test-token");
+
+        when(serverService.create(any())).thenReturn(dto);
+
+        mockMvc.perform(post("/api/servers")
+                        .cookie(adminCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("server-3"));
+    }
+
+    @Test
+    void createServer_withOperatorAuth_returns403() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-3");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.102");
+        dto.setHttpPort(8563);
+
+        mockMvc.perform(post("/api/servers")
+                        .cookie(operatorCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createServer_withReadonlyAuth_returns403() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-3");
+
+        mockMvc.perform(post("/api/servers")
+                        .cookie(readonlyCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void updateServer_withAdminAuth_returns200() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setName("更新名称");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(serverService.update(eq("server-1"), any())).thenReturn(dto);
+
+        mockMvc.perform(put("/api/servers/server-1")
+                        .cookie(adminCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("更新名称"));
+    }
+
+    @Test
+    void updateServer_withOperatorAuth_returns403() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setName("更新名称");
+
+        mockMvc.perform(put("/api/servers/server-1")
+                        .cookie(operatorCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteServer_withAdminAuth_returns204() throws Exception {
+        mockMvc.perform(delete("/api/servers/server-1").cookie(adminCookie))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteServer_withOperatorAuth_returns403() throws Exception {
+        mockMvc.perform(delete("/api/servers/server-1").cookie(operatorCookie))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteServer_withReadonlyAuth_returns403() throws Exception {
+        mockMvc.perform(delete("/api/servers/server-1").cookie(readonlyCookie))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## 关联 Issue

Closes #7

## 变更内容

### 后端改造
- **ArthasServerController**：
  - POST/PUT/DELETE 接口增加 `@RequireRole("ADMIN")` 注解
  - 所有操作增加 `@AuditLog` 注解记录审计日志
- **ArthasExecuteController**：
  - POST /api/execute 增加 `@RequireRole({"OPERATOR", "ADMIN"})` 注解
  - 已有 `@AuditLog` 注解

### 前端调整
- **ServerList.vue**：新增/编辑/删除按钮仅 ADMIN 可见
- **Diagnose.vue**：执行按钮仅 OPERATOR/ADMIN 可见

### 测试
- 新增 `ArthasServerControllerTest`：覆盖服务器 CRUD 权限控制
- 新增 `ArthasExecuteControllerTest`：覆盖命令执行权限控制

## 验收标准
- [x] 服务器增删改接口仅 ADMIN 可访问，OPERATOR/READONLY 返回 403
- [x] 命令执行接口 OPERATOR 和 ADMIN 可访问，READONLY 返回 403
- [x] 所有操作正确记录审计日志
- [x] 高危命令在执行前被拦截（已有实现）
- [x] 前端根据角色控制按钮显隐
- [x] 数据库初始化包含默认管理员和三个角色（已有实现）

## 测试结果
```
Tests run: 117, Failures: 0, Errors: 0, Skipped: 0
```