### PR TITLE
[P0] 修复登录时审计日志保存失败导致 Internal Server Error (#57)

### DIFF
--- a/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
+++ b/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
@@ -126,6 +126,8 @@ public class AuditLogAspect {
                 auditEntry.setTarget(value);
             } else if ("target".equals(fieldName) && auditEntry.getTarget() == null) {
                 auditEntry.setTarget(value);
+            } else if ("username".equals(fieldName) && auditEntry.getUsername() == null) {
+                auditEntry.setUsername(value);
             }
         }
     }

--- a/src/test/java/com/zhenduanqi/aspect/AuditLogAspectTest.java
+++ b/src/test/java/com/zhenduanqi/aspect/AuditLogAspectTest.java
@@ -147,6 +147,28 @@ class AuditLogAspectTest {
     }
 
     @Test
+    void loginRequest_withoutUsernameInRequestAttribute_extractsFromLoginRequest() throws Throwable {
+        request.setAttribute("username", null);
+        
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getMethod()).thenReturn(
+                AuditLogAspectTest.class.getDeclaredMethod("loginMethodWithDTO", LoginRequest.class));
+        LoginRequest req = new LoginRequest();
+        req.setUsername("admin");
+        req.setPassword("secret123");
+        when(joinPoint.getArgs()).thenReturn(new Object[]{req});
+        when(joinPoint.proceed()).thenReturn("success");
+
+        aspect.logAround(joinPoint);
+
+        ArgumentCaptor<SysAuditLog> captor = ArgumentCaptor.forClass(SysAuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        SysAuditLog log = captor.getValue();
+        assertThat(log.getUsername()).isEqualTo("admin");
+        assertThat(log.getAction()).isEqualTo("LOGIN");
+    }
+
+    @Test
     void executeResponse_succeeded_recordsSuccess() throws Throwable {
         when(joinPoint.getSignature()).thenReturn(signature);
         when(signature.getMethod()).thenReturn(


### PR DESCRIPTION
## 问题

使用正确密码登录时，返回 Internal Server Error。

## 根本原因

1. AuthInterceptor 放行了 /api/auth/login 路径，不设置 username 属性
2. AuditLogAspect 在方法执行前从 request 获取 username，此时为 null
3. 数据库 SysAuditLog.username 是 NOT NULL，导致保存失败

异常信息：
```
org.hibernate.PropertyValueException: not-null property references a null or transient value : com.zhenduanqi.entity.SysAuditLog.username
```

## 修复方案

在 AuditLogAspect 的 extractFromJson 方法中，当 username 为 null 时，从方法参数（如 LoginRequest）中提取 username 字段。

## 测试

- 新增测试用例 `loginRequest_withoutUsernameInRequestAttribute_extractsFromLoginRequest`
- 所有 118 个测试通过

Closes #57