### PR TITLE
feat(scene): 实现场景列表页、诊断页和半自动变量填充 (#28)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -968,15 +968,15 @@ zhenduanqi/
 - ✅ 服务器 Token 加密存储（AES-256-GCM）
 - ✅ 前端登录页 + 路由守卫 + 角色按钮控制
 
-### 第二阶段（P1）：场景模板引擎 — 基础版 ✅ 已完成后端部分
+### 第二阶段（P1）：场景模板引擎 — 基础版 ✅ 已完成
 目标：实现一次性命令场景的诊断向导
 - ✅ 场景/步骤 CRUD 管理（含新增字段：category、business_scenario、continuous、maxExecTime、extract_rules）
 - ✅ 8 个预置场景（场景1-5 为一次性命令，场景6-8 为连续命令暂用 exec + -n 限制）
-- 场景列表页（按分类卡片展示 + 业务场景检索）
-- 场景诊断页（步骤列表 + 手动执行 + 结果渲染）
-- 前端渲染器：thread、memory、status、enhancer + 降级文本
-- 半自动变量填充（extract_rules + jsonpath-plus）
-- 前端 diagnose store（步骤状态管理、变量缓存）
+- ✅ 场景列表页（按分类卡片展示 + 业务场景检索）
+- ✅ 场景诊断页（步骤列表 + 手动执行 + 结果渲染）
+- ✅ 前端渲染器：thread、memory、status、enhancer + 降级文本
+- ✅ 半自动变量填充（extract_rules + jsonpath-plus）
+- ✅ 前端 diagnose store（步骤状态管理、变量缓存）
 
 ### 第三阶段（P2）：场景模板引擎 — 异步版
 目标：实现连续输出命令场景的诊断 + 会话安全管控

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "vue-router": "^4.3.0",
     "pinia": "^2.1.7",
     "axios": "^1.6.8",
-    "element-plus": "^2.7.0"
+    "element-plus": "^2.7.0",
+    "jsonpath-plus": "^10.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -103,3 +103,43 @@ export function updateGuardRule(id, data) {
 export function deleteGuardRule(id) {
   return api.delete(`/command-guard/rules/${id}`);
 }
+
+export function getScenes(params) {
+  return api.get('/scenes', { params });
+}
+
+export function getSceneById(id) {
+  return api.get(`/scenes/${id}`);
+}
+
+export function getSceneSteps(sceneId) {
+  return api.get(`/scenes/${sceneId}/steps`);
+}
+
+export function createScene(data) {
+  return api.post('/scenes', data);
+}
+
+export function updateScene(id, data) {
+  return api.put(`/scenes/${id}`, data);
+}
+
+export function deleteScene(id) {
+  return api.delete(`/scenes/${id}`);
+}
+
+export function addSceneStep(sceneId, data) {
+  return api.post(`/scenes/${sceneId}/steps`, data);
+}
+
+export function updateSceneStep(stepId, data) {
+  return api.put(`/scenes/steps/${stepId}`, data);
+}
+
+export function deleteSceneStep(stepId) {
+  return api.delete(`/scenes/steps/${stepId}`);
+}
+
+export function reorderSceneSteps(sceneId, stepIds) {
+  return api.put(`/scenes/${sceneId}/steps/reorder`, { stepIds });
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,6 +2,7 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import ElementPlus from 'element-plus';
 import 'element-plus/dist/index.css';
+import * as ElementPlusIconsVue from '@element-plus/icons-vue';
 import App from './App.vue';
 import router from './router';
 
@@ -9,4 +10,9 @@ const app = createApp(App);
 app.use(createPinia());
 app.use(router);
 app.use(ElementPlus);
+
+for (const [key, component] of Object.entries(ElementPlusIconsVue)) {
+  app.component(key, component);
+}
+
 app.mount('#app');

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,18 +8,30 @@ const routes = [
   },
   {
     path: '/',
-    redirect: '/diagnose',
+    redirect: '/scenes',
   },
   {
-    path: '/servers',
-    name: 'ServerList',
-    component: () => import('../views/ServerList.vue'),
+    path: '/scenes',
+    name: 'SceneList',
+    component: () => import('../views/SceneList.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
+    path: '/scenes/:id/diagnose',
+    name: 'SceneDiagnose',
+    component: () => import('../views/SceneDiagnose.vue'),
     meta: { requiresAuth: true },
   },
   {
     path: '/diagnose',
     name: 'Diagnose',
     component: () => import('../views/Diagnose.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
+    path: '/servers',
+    name: 'ServerList',
+    component: () => import('../views/ServerList.vue'),
     meta: { requiresAuth: true },
   },
   {

--- a/frontend/src/stores/diagnose.js
+++ b/frontend/src/stores/diagnose.js
@@ -1,0 +1,130 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { JSONPath } from 'jsonpath-plus';
+
+export const useDiagnoseStore = defineStore('diagnose', () => {
+  const currentSceneId = ref(null);
+  const currentSceneName = ref('');
+  const selectedServerId = ref(null);
+  const steps = ref([]);
+  const variables = ref(new Map());
+  const stepResults = ref(new Map());
+
+  function initScene(scene, serverId) {
+    currentSceneId.value = scene.id;
+    currentSceneName.value = scene.name;
+    selectedServerId.value = serverId;
+    steps.value = scene.steps || [];
+    variables.value = new Map();
+    stepResults.value = new Map();
+  }
+
+  function reset() {
+    currentSceneId.value = null;
+    currentSceneName.value = '';
+    selectedServerId.value = null;
+    steps.value = [];
+    variables.value = new Map();
+    stepResults.value = new Map();
+  }
+
+  function extractVariables(stepId, results) {
+    const step = steps.value.find(s => s.id === stepId);
+    if (!step || !step.extract_rules) {
+      return;
+    }
+
+    let rules;
+    try {
+      rules = typeof step.extract_rules === 'string'
+        ? JSON.parse(step.extract_rules)
+        : step.extract_rules;
+    } catch {
+      return;
+    }
+
+    const data = { results: results || [] };
+
+    for (const rule of rules) {
+      if (!rule.variable || !rule.jsonPath) {
+        continue;
+      }
+
+      try {
+        const values = JSONPath({
+          path: rule.jsonPath,
+          json: data,
+          resultType: 'value'
+        });
+
+        if (values && values.length > 0) {
+          variables.value.set(rule.variable, String(values[0]));
+        }
+      } catch {
+        console.warn(`Failed to extract variable ${rule.variable} with jsonPath: ${rule.jsonPath}`);
+      }
+    }
+  }
+
+  function fillCommand(stepId) {
+    const step = steps.value.find(s => s.id === stepId);
+    if (!step) {
+      return '';
+    }
+
+    let command = step.command || '';
+
+    for (const [key, value] of variables.value.entries()) {
+      const placeholder = `{${key}}`;
+      if (command.includes(placeholder)) {
+        command = command.replaceAll(placeholder, value);
+      }
+    }
+
+    return command;
+  }
+
+  function getPreFilledCommand(stepId) {
+    return fillCommand(stepId);
+  }
+
+  function saveStepResult(stepId, result) {
+    stepResults.value.set(stepId, result);
+    extractVariables(stepId, result.results);
+  }
+
+  function getStepResult(stepId) {
+    return stepResults.value.get(stepId);
+  }
+
+  function getVariables() {
+    return Object.fromEntries(variables.value);
+  }
+
+  function setVariable(key, value) {
+    variables.value.set(key, String(value));
+  }
+
+  function getVariable(key) {
+    return variables.value.get(key);
+  }
+
+  return {
+    currentSceneId,
+    currentSceneName,
+    selectedServerId,
+    steps,
+    variables,
+    stepResults,
+    initScene,
+    reset,
+    extractVariables,
+    fillCommand,
+    getPreFilledCommand,
+    saveStepResult,
+    getStepResult,
+    getVariables,
+    setVariable,
+    getVariable
+  };
+});

--- a/frontend/src/stores/diagnose.js
+++ b/frontend/src/stores/diagnose.js
@@ -43,26 +43,26 @@ export const useDiagnoseStore = defineStore('diagnose', () => {
       return;
     }
 
-    const data = { results: results || [] };
+    const data = results || [];
 
     for (const rule of rules) {
-      if (!rule.variable || !rule.jsonPath) {
-        continue;
-      }
-
-      try {
-        const values = JSONPath({
-          path: rule.jsonPath,
-          json: data,
-          resultType: 'value'
-        });
-
-        if (values && values.length > 0) {
-          variables.value.set(rule.variable, String(values[0]));
+        if (!rule.variable || !rule.jsonPath) {
+            continue;
         }
-      } catch {
-        console.warn(`Failed to extract variable ${rule.variable} with jsonPath: ${rule.jsonPath}`);
-      }
+
+        try {
+            const values = JSONPath({
+                path: rule.jsonPath,
+                json: data,
+                resultType: 'value'
+            });
+
+            if (values && values.length > 0) {
+                variables.value.set(rule.variable, String(values[0]));
+            }
+        } catch (error) {
+            console.warn(`Failed to extract variable ${rule.variable} with jsonPath: ${rule.jsonPath}`, error);
+        }
     }
   }
 

--- a/frontend/src/stores/diagnose.test.js
+++ b/frontend/src/stores/diagnose.test.js
@@ -19,7 +19,7 @@ describe('useDiagnoseStore', () => {
             id: 101,
             command: 'thread -b',
             extract_rules: JSON.stringify([
-              { variable: 'threadId', jsonPath: '$.results[?(@.type=="thread")][0].data.threadId', description: 'Extract first thread id' }
+              { variable: 'threadId', jsonPath: '$[?(@.type=="thread")][0].data.threadId', description: 'Extract first thread id' }
             ])
           }
         ]
@@ -27,13 +27,11 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = {
-        results: [
-          { type: 'thread', data: { threadId: 42, name: 'Thread-1', state: 'BLOCKED' } }
-        ]
-      };
+      const results = [
+        { type: 'thread', data: { threadId: 42, name: 'Thread-1', state: 'BLOCKED' } }
+      ];
 
-      store.extractVariables(101, results.results);
+      store.extractVariables(101, results);
 
       expect(store.getVariable('threadId')).toBe('42');
     });
@@ -49,8 +47,8 @@ describe('useDiagnoseStore', () => {
             id: 101,
             command: 'thread -n 5',
             extract_rules: JSON.stringify([
-              { variable: 'threadId', jsonPath: '$.results[0].data.threadId', description: 'First thread id' },
-              { variable: 'threadName', jsonPath: '$.results[0].data.name', description: 'First thread name' }
+              { variable: 'threadId', jsonPath: '$[0].data.threadId', description: 'First thread id' },
+              { variable: 'threadName', jsonPath: '$[0].data.name', description: 'First thread name' }
             ])
           }
         ]
@@ -58,13 +56,11 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = {
-        results: [
-          { type: 'thread', data: { threadId: 123, name: 'Worker-Thread-1' } }
-        ]
-      };
+      const results = [
+        { type: 'thread', data: { threadId: 123, name: 'Worker-Thread-1' } }
+      ];
 
-      store.extractVariables(101, results.results);
+      store.extractVariables(101, results);
 
       expect(store.getVariable('threadId')).toBe('123');
       expect(store.getVariable('threadName')).toBe('Worker-Thread-1');
@@ -83,13 +79,11 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = {
-        results: [
-          { type: 'thread', data: { threadId: 42 } }
-        ]
-      };
+      const results = [
+        { type: 'thread', data: { threadId: 42 } }
+      ];
 
-      store.extractVariables(101, results.results);
+      store.extractVariables(101, results);
 
       expect(store.getVariable('threadId')).toBeUndefined();
     });
@@ -113,9 +107,9 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = { results: [] };
+      const results = [];
 
-      expect(() => store.extractVariables(101, results.results)).not.toThrow();
+      expect(() => store.extractVariables(101, results)).not.toThrow();
       expect(store.getVariable('testVar')).toBeUndefined();
     });
 
@@ -132,9 +126,37 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = { results: [] };
+      const results = [];
 
-      expect(() => store.extractVariables(101, results.results)).not.toThrow();
+      expect(() => store.extractVariables(101, results)).not.toThrow();
+    });
+
+    it('should support simple array index jsonpath for data.sql format', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          {
+            id: 101,
+            command: 'thread -n 5',
+            extract_rules: JSON.stringify([
+              { variable: 'threadId', jsonPath: '$[0].id', description: 'First thread id from simple array' }
+            ])
+          }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const results = [
+        { id: 123, name: 'Worker-Thread-1' }
+      ];
+
+      store.extractVariables(101, results);
+
+      expect(store.getVariable('threadId')).toBe('123');
     });
   });
 
@@ -235,7 +257,10 @@ describe('useDiagnoseStore', () => {
         steps: [
           {
             id: 101,
-            command: 'thread {threadId}'
+            command: 'thread {threadId}',
+            extract_rules: JSON.stringify([
+              { variable: 'threadId', jsonPath: '$[0].data.threadId' }
+            ])
           }
         ]
       };
@@ -264,7 +289,7 @@ describe('useDiagnoseStore', () => {
             id: 101,
             command: 'thread -b',
             extract_rules: JSON.stringify([
-              { variable: 'threadId', jsonPath: '$.results[0].data.threadId' }
+              { variable: 'threadId', jsonPath: '$[0].data.threadId' }
             ])
           }
         ]

--- a/frontend/src/stores/diagnose.test.js
+++ b/frontend/src/stores/diagnose.test.js
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useDiagnoseStore } from '../stores/diagnose';
+
+describe('useDiagnoseStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('extractVariables', () => {
+    it('should extract variable from thread result using jsonpath', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Thread Deadlock Detection',
+        steps: [
+          {
+            id: 101,
+            command: 'thread -b',
+            extract_rules: JSON.stringify([
+              { variable: 'threadId', jsonPath: '$.results[?(@.type=="thread")][0].data.threadId', description: 'Extract first thread id' }
+            ])
+          }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const results = {
+        results: [
+          { type: 'thread', data: { threadId: 42, name: 'Thread-1', state: 'BLOCKED' } }
+        ]
+      };
+
+      store.extractVariables(101, results.results);
+
+      expect(store.getVariable('threadId')).toBe('42');
+    });
+
+    it('should extract multiple variables from results', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          {
+            id: 101,
+            command: 'thread -n 5',
+            extract_rules: JSON.stringify([
+              { variable: 'threadId', jsonPath: '$.results[0].data.threadId', description: 'First thread id' },
+              { variable: 'threadName', jsonPath: '$.results[0].data.name', description: 'First thread name' }
+            ])
+          }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const results = {
+        results: [
+          { type: 'thread', data: { threadId: 123, name: 'Worker-Thread-1' } }
+        ]
+      };
+
+      store.extractVariables(101, results.results);
+
+      expect(store.getVariable('threadId')).toBe('123');
+      expect(store.getVariable('threadName')).toBe('Worker-Thread-1');
+    });
+
+    it('should not extract variables when step has no extract_rules', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          { id: 101, command: 'thread -b' }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const results = {
+        results: [
+          { type: 'thread', data: { threadId: 42 } }
+        ]
+      };
+
+      store.extractVariables(101, results.results);
+
+      expect(store.getVariable('threadId')).toBeUndefined();
+    });
+
+    it('should handle invalid jsonpath gracefully', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          {
+            id: 101,
+            command: 'test',
+            extract_rules: JSON.stringify([
+              { variable: 'testVar', jsonPath: '$.invalid[?(@.nonexistent', description: 'Invalid jsonpath' }
+            ])
+          }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const results = { results: [] };
+
+      expect(() => store.extractVariables(101, results.results)).not.toThrow();
+      expect(store.getVariable('testVar')).toBeUndefined();
+    });
+
+    it('should handle invalid extract_rules JSON gracefully', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          { id: 101, command: 'test', extract_rules: 'not valid json' }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const results = { results: [] };
+
+      expect(() => store.extractVariables(101, results.results)).not.toThrow();
+    });
+  });
+
+  describe('fillCommand', () => {
+    it('should replace single placeholder with extracted variable', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          { id: 101, command: 'thread {threadId}' }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+      store.setVariable('threadId', '42');
+
+      const filled = store.fillCommand(101);
+
+      expect(filled).toBe('thread 42');
+    });
+
+    it('should replace multiple placeholders with extracted variables', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          { id: 101, command: 'trace {className} {methodName} -n 5' }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+      store.setVariable('className', 'com.example.UserService');
+      store.setVariable('methodName', 'getUser');
+
+      const filled = store.fillCommand(101);
+
+      expect(filled).toBe('trace com.example.UserService getUser -n 5');
+    });
+
+    it('should not replace placeholders that have no variable', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          { id: 101, command: 'watch {className} {methodName}' }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+      store.setVariable('className', 'com.example.Service');
+
+      const filled = store.fillCommand(101);
+
+      expect(filled).toBe('watch com.example.Service {methodName}');
+    });
+
+    it('should return empty string for non-existent step', () => {
+      const store = useDiagnoseStore();
+      store.initScene({ id: 1, steps: [] }, 'server-1');
+
+      const filled = store.fillCommand(999);
+
+      expect(filled).toBe('');
+    });
+
+    it('should handle command with no placeholders', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          { id: 101, command: 'dashboard -n 1' }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const filled = store.fillCommand(101);
+
+      expect(filled).toBe('dashboard -n 1');
+    });
+  });
+
+  describe('getPreFilledCommand', () => {
+    it('should return pre-filled command using stored variables', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          {
+            id: 101,
+            command: 'thread {threadId}'
+          }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      store.extractVariables(101, [
+        { type: 'thread', data: { threadId: 99 } }
+      ]);
+
+      const preFilled = store.getPreFilledCommand(101);
+
+      expect(preFilled).toBe('thread 99');
+    });
+  });
+
+  describe('saveStepResult', () => {
+    it('should save result and extract variables', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [
+          {
+            id: 101,
+            command: 'thread -b',
+            extract_rules: JSON.stringify([
+              { variable: 'threadId', jsonPath: '$.results[0].data.threadId' }
+            ])
+          }
+        ]
+      };
+
+      store.initScene(scene, 'server-1');
+
+      const result = {
+        state: 'SUCCESS',
+        results: [
+          { type: 'thread', data: { threadId: 55 } }
+        ]
+      };
+
+      store.saveStepResult(101, result);
+
+      expect(store.getStepResult(101)).toEqual(result);
+      expect(store.getVariable('threadId')).toBe('55');
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear all state including variables', () => {
+      const store = useDiagnoseStore();
+
+      const scene = {
+        id: 1,
+        name: 'Test Scene',
+        steps: [{ id: 101, command: 'test' }]
+      };
+
+      store.initScene(scene, 'server-1');
+      store.setVariable('testVar', 'testValue');
+      store.saveStepResult(101, { state: 'SUCCESS' });
+
+      store.reset();
+
+      expect(store.currentSceneId).toBeNull();
+      expect(store.currentSceneName).toBe('');
+      expect(store.selectedServerId).toBeNull();
+      expect(store.steps).toEqual([]);
+      expect(store.variables.size).toBe(0);
+      expect(store.stepResults.size).toBe(0);
+    });
+  });
+
+  describe('getVariables', () => {
+    it('should return plain object from Map', () => {
+      const store = useDiagnoseStore();
+      store.setVariable('var1', 'value1');
+      store.setVariable('var2', '123');
+
+      const vars = store.getVariables();
+
+      expect(vars).toEqual({ var1: 'value1', var2: '123' });
+    });
+
+    it('should return empty object when no variables', () => {
+      const store = useDiagnoseStore();
+
+      const vars = store.getVariables();
+
+      expect(vars).toEqual({});
+    });
+  });
+});

--- a/frontend/src/views/SceneDiagnose.vue
+++ b/frontend/src/views/SceneDiagnose.vue
@@ -1,0 +1,352 @@
+<template>
+  <div>
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px">
+      <div>
+        <el-button text @click="goBack">
+          <el-icon><ArrowLeft /></el-icon>
+          返回场景列表
+        </el-button>
+        <h2 style="margin: 8px 0 0 0">{{ diagnoseStore.currentSceneName }}</h2>
+      </div>
+      <div style="display: flex; gap: 12px; align-items: center">
+        <el-tag v-if="diagnoseStore.selectedServerId" type="info">
+          {{ getServerName(diagnoseStore.selectedServerId) }}
+        </el-tag>
+        <el-button type="danger" @click="handleReset">
+          开始新诊断
+        </el-button>
+      </div>
+    </div>
+
+    <div v-if="diagnoseStore.steps.length === 0" style="text-align: center; padding: 60px 0; color: #909399">
+      <p>暂无诊断步骤</p>
+    </div>
+
+    <div v-else class="steps-container">
+      <el-card
+        v-for="(step, index) in diagnoseStore.steps"
+        :key="step.id"
+        class="step-card"
+        :class="{
+          'step-completed': stepStates[index]?.state === 'completed',
+          'step-executing': stepStates[index]?.state === 'executing',
+          'step-error': stepStates[index]?.state === 'error'
+        }"
+        style="margin-bottom: 16px"
+      >
+        <template #header>
+          <div style="display: flex; justify-content: space-between; align-items: center">
+            <div style="display: flex; align-items: center; gap: 12px">
+              <el-tag :type="getStepTagType(stepStates[index]?.state)" size="small">
+                步骤 {{ index + 1 }}
+              </el-tag>
+              <span style="font-weight: 600">{{ step.title || '步骤 ' + (index + 1) }}</span>
+            </div>
+            <div v-if="stepStates[index]?.state === 'completed'" style="color: #67c23a">
+              <el-icon><CircleCheck /></el-icon>
+              已完成
+            </div>
+            <div v-else-if="stepStates[index]?.state === 'executing'" style="color: #409eff">
+              <el-icon class="is-loading"><Loading /></el-icon>
+              执行中...
+            </div>
+          </div>
+        </template>
+
+        <div class="step-content">
+          <p v-if="step.description" class="step-description">
+            <el-icon><InfoFilled /></el-icon>
+            {{ step.description }}
+          </p>
+
+          <div class="command-input-area">
+            <el-input
+              v-model="stepCommands[index]"
+              :placeholder="step.command"
+              :disabled="stepStates[index]?.state === 'executing'"
+              @keyup.enter="handleExecute(index)"
+            >
+              <template #append>
+                <el-button
+                  :loading="stepStates[index]?.state === 'executing'"
+                  :disabled="!diagnoseStore.selectedServerId || stepStates[index]?.state === 'executing'"
+                  @click="handleExecute(index)"
+                >
+                  <el-icon v-if="!stepStates[index]?.state"><VideoPlay /></el-icon>
+                  执行
+                </el-button>
+              </template>
+            </el-input>
+            <div v-if="hasPlaceholder(step.command) && stepStates[index]?.state !== 'completed'" class="placeholder-hint">
+              <el-icon><Warning /></el-icon>
+              命令包含占位符 { {{ getUnfilledPlaceholders(step.command) }} }，将从上一步结果自动提取
+            </div>
+          </div>
+
+          <div v-if="stepStates[index]?.result" class="step-result" style="margin-top: 16px">
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px">
+              <span style="font-weight: 500">执行结果</span>
+              <el-tag v-if="stepStates[index]?.result.state === 'succeeded'" type="success" size="small">成功</el-tag>
+              <el-tag v-else-if="stepStates[index]?.result.state === 'failed'" type="danger" size="small">失败</el-tag>
+              <el-tag v-else type="info" size="small">{{ stepStates[index]?.result.state }}</el-tag>
+            </div>
+
+            <div v-if="stepStates[index]?.result.error" style="color: #f56c6c; margin-bottom: 8px">
+              {{ stepStates[index]?.result.error }}
+            </div>
+
+            <div v-for="(r, i) in stepStates[index]?.result.structuredResults" :key="i">
+              <component :is="getRenderer(r.type)" :data="r.data" />
+            </div>
+
+            <div v-if="stepStates[index]?.result.results && stepStates[index]?.result.results.length > 0 && !stepStates[index]?.result.structuredResults">
+              <div v-for="(r, i) in stepStates[index]?.result.results" :key="'raw-' + i">
+                <pre class="result-raw">{{ typeof r === 'string' ? r : JSON.stringify(r, null, 2) }}</pre>
+              </div>
+            </div>
+
+            <div v-if="stepStates[index]?.result.results && stepStates[index]?.result.results.length > 0" style="margin-top: 12px">
+              <el-button size="small" text @click="expandRaw[index] = !expandRaw[index]">
+                {{ expandRaw[index] ? '收起' : '查看' }}原始响应
+              </el-button>
+              <pre v-if="expandRaw[index]" class="result-raw" style="margin-top: 8px">{{ stepStates[index]?.result.rawResponse }}</pre>
+            </div>
+          </div>
+
+          <div v-if="step.expectedHint" class="step-hint" style="margin-top: 12px">
+            <el-icon style="color: #e6a23c"><InfoFilled /></el-icon>
+            {{ step.expectedHint }}
+          </div>
+
+          <div v-if="stepStates[index]?.state === 'completed' && step.extract_rules" class="variables-extracted" style="margin-top: 12px">
+            <span style="color: #67c23a; font-size: 13px">
+              <el-icon><Check /></el-icon>
+              已提取变量:
+            </span>
+            <el-tag
+              v-for="[key, value] in getExtractedVariables(step.id)"
+              :key="key"
+              size="small"
+              style="margin-left: 8px"
+            >
+              {{ key }} = {{ value }}
+            </el-tag>
+          </div>
+        </div>
+      </el-card>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted, watch } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { ElMessage, ElMessageBox } from 'element-plus';
+import {
+  ArrowLeft, VideoPlay, CircleCheck, Loading, InfoFilled, Warning, Check
+} from '@element-plus/icons-vue';
+import { executeCommand, getServerById } from '../api';
+import { useDiagnoseStore } from '../stores/diagnose';
+import { useServerStore } from '../stores/servers';
+import { getRenderer } from '../components/ResultRenderer';
+
+const router = useRouter();
+const route = useRoute();
+const diagnoseStore = useDiagnoseStore();
+const serverStore = useServerStore();
+
+const stepCommands = ref([]);
+const stepStates = ref([]);
+const expandRaw = ref([]);
+const serverNames = ref({});
+
+function getStepTagType(state) {
+  if (state === 'completed') return 'success';
+  if (state === 'executing') return 'warning';
+  if (state === 'error') return 'danger';
+  return 'info';
+}
+
+function hasPlaceholder(command) {
+  if (!command) return false;
+  const matches = command.match(/\{(\w+)\}/g);
+  return matches && matches.length > 0;
+}
+
+function getUnfilledPlaceholders(command) {
+  if (!command) return '';
+  const matches = command.match(/\{(\w+)\}/g) || [];
+  const unfilled = matches
+    .map(m => m.slice(1, -1))
+    .filter(key => !diagnoseStore.variables.has(key));
+  return [...new Set(unfilled)].join(', ');
+}
+
+function getExtractedVariables(stepId) {
+  const variables = [];
+  for (const [key, value] of diagnoseStore.variables.entries()) {
+    variables.push([key, value]);
+  }
+  return variables;
+}
+
+function getServerName(serverId) {
+  return serverNames.value[serverId] || serverId;
+}
+
+async function loadServerNames() {
+  if (diagnoseStore.selectedServerId) {
+    try {
+      const res = await getServerById(diagnoseStore.selectedServerId);
+      serverNames.value[diagnoseStore.selectedServerId] = res.data.name;
+    } catch {
+      serverNames.value[diagnoseStore.selectedServerId] = diagnoseStore.selectedServerId;
+    }
+  }
+}
+
+function initializeStepCommands() {
+  stepCommands.value = diagnoseStore.steps.map((step, index) => {
+    return diagnoseStore.getPreFilledCommand(step.id) || step.command || '';
+  });
+  stepStates.value = diagnoseStore.steps.map(() => ({}));
+  expandRaw.value = diagnoseStore.steps.map(() => false);
+}
+
+async function handleExecute(index) {
+  const step = diagnoseStore.steps[index];
+  const command = stepCommands.value[index] || step.command;
+
+  if (!command || !command.trim()) {
+    ElMessage.warning('请输入命令');
+    return;
+  }
+
+  stepStates.value[index] = { state: 'executing', result: null };
+
+  try {
+    const res = await executeCommand(diagnoseStore.selectedServerId, command);
+    const result = res.data;
+
+    stepStates.value[index] = { state: 'completed', result };
+
+    diagnoseStore.saveStepResult(step.id, result);
+
+    for (let i = index + 1; i < diagnoseStore.steps.length; i++) {
+      const nextStep = diagnoseStore.steps[i];
+      stepCommands.value[i] = diagnoseStore.getPreFilledCommand(nextStep.id) || nextStep.command || '';
+    }
+  } catch (e) {
+    stepStates.value[index] = {
+      state: 'error',
+      result: {
+        state: 'failed',
+        error: e.response?.data?.error || e.message || '执行失败',
+        results: []
+      }
+    };
+    ElMessage.error(e.response?.data?.error || '命令执行失败');
+  }
+}
+
+async function handleReset() {
+  try {
+    await ElMessageBox.confirm(
+      '确定要开始新的诊断吗？当前诊断进度将丢失。',
+      '确认重置',
+      { confirmButtonText: '确定', cancelButtonText: '取消', type: 'warning' }
+    );
+    diagnoseStore.reset();
+    router.push('/scenes');
+  } catch {
+  }
+}
+
+function goBack() {
+  router.push('/scenes');
+}
+
+onMounted(async () => {
+  if (!diagnoseStore.currentSceneId) {
+    router.push('/scenes');
+    return;
+  }
+
+  await loadServerNames();
+  initializeStepCommands();
+});
+</script>
+
+<style scoped>
+.step-card {
+  border-left: 4px solid #dcdfe6;
+  transition: border-color 0.3s;
+}
+
+.step-card.step-completed {
+  border-left-color: #67c23a;
+}
+
+.step-card.step-executing {
+  border-left-color: #409eff;
+}
+
+.step-card.step-error {
+  border-left-color: #f56c6c;
+}
+
+.step-description {
+  color: #606266;
+  font-size: 14px;
+  margin: 0 0 12px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.command-input-area {
+  margin-bottom: 8px;
+}
+
+.placeholder-hint {
+  color: #e6a23c;
+  font-size: 12px;
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.step-result {
+  background: #f5f7fa;
+  padding: 12px;
+  border-radius: 4px;
+}
+
+.step-hint {
+  background: #fdf6ec;
+  color: #e6a23c;
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.variables-extracted {
+  background: #f0f9eb;
+  padding: 8px 12px;
+  border-radius: 4px;
+}
+
+.result-raw {
+  background: #fff;
+  padding: 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 0;
+}
+</style>

--- a/frontend/src/views/SceneList.vue
+++ b/frontend/src/views/SceneList.vue
@@ -1,0 +1,298 @@
+<template>
+  <div>
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px">
+      <div>
+        <h2 style="margin: 0">诊断场景</h2>
+        <p style="color: #909399; margin: 4px 0 0 0; font-size: 14px">
+          选择一个场景，按步骤引导进行诊断
+        </p>
+      </div>
+      <div style="display: flex; gap: 12px">
+        <el-input
+          v-model="searchKeyword"
+          placeholder="搜索业务场景..."
+          style="width: 240px"
+          clearable
+          @input="handleSearch"
+        >
+          <template #prefix>
+            <el-icon><Search /></el-icon>
+          </template>
+        </el-input>
+        <el-select v-model="selectedCategory" placeholder="全部分类" clearable style="width: 160px" @change="handleCategoryChange">
+          <el-option label="线程问题" value="THREAD" />
+          <el-option label="内存问题" value="MEMORY" />
+          <el-option label="JVM 基础" value="JVM" />
+          <el-option label="方法调试" value="METHOD" />
+          <el-option label="类加载问题" value="CLASSLOADER" />
+        </el-select>
+      </div>
+    </div>
+
+    <div v-loading="loading">
+      <div v-if="filteredScenes.length === 0 && !loading" style="text-align: center; padding: 60px 0; color: #909399">
+        <el-icon :size="48"><Folder /></el-icon>
+        <p style="margin-top: 16px">暂无场景数据</p>
+      </div>
+
+      <el-row :gutter="20" v-else>
+        <el-col
+          v-for="scene in filteredScenes"
+          :key="scene.id"
+          :xs="24"
+          :sm="12"
+          :md="8"
+          :lg="6"
+          style="margin-bottom: 20px"
+        >
+          <el-card
+            class="scene-card"
+            :body-style="{ padding: '0' }"
+            shadow="hover"
+            @click="enterScene(scene)"
+          >
+            <div class="scene-card-header" :style="{ backgroundColor: getCategoryColor(scene.category) }">
+              <el-icon :size="28" style="color: white">
+                <component :is="getCategoryIcon(scene.category)" />
+              </el-icon>
+            </div>
+            <div class="scene-card-body">
+              <h3 class="scene-title">{{ scene.name }}</h3>
+              <p class="scene-desc">{{ scene.description || '暂无描述' }}</p>
+              <div class="scene-meta">
+                <el-tag size="small" :type="getCategoryTagType(scene.category)">
+                  {{ getCategoryName(scene.category) }}
+                </el-tag>
+                <span class="step-count">{{ scene.stepCount || 0 }} 个步骤</span>
+              </div>
+              <p v-if="scene.businessScenario" class="scene-business">
+                <el-icon><Location /></el-icon>
+                {{ scene.businessScenario }}
+              </p>
+            </div>
+          </el-card>
+        </el-col>
+      </el-row>
+    </div>
+
+    <el-dialog v-model="showServerDialog" title="选择目标服务器" width="500px" :close-on-click-modal="false">
+      <el-form label-width="100px">
+        <el-form-item label="目标服务器" required>
+          <el-select v-model="selectedServerId" placeholder="请选择服务器" style="width: 100%">
+            <el-option
+              v-for="s in serverStore.list"
+              :key="s.id"
+              :label="s.name + ' (' + s.host + ':' + s.httpPort + ')'"
+              :value="s.id"
+            />
+          </el-select>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="showServerDialog = false">取消</el-button>
+        <el-button type="primary" :disabled="!selectedServerId" @click="confirmEnterScene">
+          开始诊断
+        </el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import { Search, Folder, Location, Odometer, DataAnalysis, Box, Connection, Monitor } from '@element-plus/icons-vue';
+import { getScenes, getSceneSteps } from '../api';
+import { useServerStore } from '../stores/servers';
+import { useDiagnoseStore } from '../stores/diagnose';
+
+const router = useRouter();
+const serverStore = useServerStore();
+const diagnoseStore = useDiagnoseStore();
+
+const loading = ref(false);
+const scenes = ref([]);
+const searchKeyword = ref('');
+const selectedCategory = ref('');
+const showServerDialog = ref(false);
+const selectedServerId = ref('');
+const pendingScene = ref(null);
+
+const categoryMap = {
+  THREAD: { name: '线程问题', color: '#409EFF', tagType: '' },
+  MEMORY: { name: '内存问题', color: '#67C23A', tagType: 'success' },
+  JVM: { name: 'JVM 基础', color: '#E6A23C', tagType: 'warning' },
+  METHOD: { name: '方法调试', color: '#9B59B6', tagType: 'info' },
+  CLASSLOADER: { name: '类加载问题', color: '#F56C6C', tagType: 'danger' }
+};
+
+const filteredScenes = computed(() => {
+  let result = scenes.value;
+
+  if (selectedCategory.value) {
+    result = result.filter(s => s.category === selectedCategory.value);
+  }
+
+  if (searchKeyword.value) {
+    const keyword = searchKeyword.value.toLowerCase();
+    result = result.filter(s =>
+      s.name.toLowerCase().includes(keyword) ||
+      (s.businessScenario && s.businessScenario.toLowerCase().includes(keyword)) ||
+      (s.description && s.description.toLowerCase().includes(keyword))
+    );
+  }
+
+  return result;
+});
+
+function getCategoryName(category) {
+  return categoryMap[category]?.name || category;
+}
+
+function getCategoryColor(category) {
+  return categoryMap[category]?.color || '#909399';
+}
+
+function getCategoryTagType(category) {
+  return categoryMap[category]?.tagType || '';
+}
+
+function getCategoryIcon(category) {
+  const iconMap = {
+    THREAD: Odometer,
+    MEMORY: DataAnalysis,
+    JVM: Box,
+    METHOD: Monitor,
+    CLASSLOADER: Connection
+  };
+  return iconMap[category] || Folder;
+}
+
+async function fetchScenes() {
+  loading.value = true;
+  try {
+    const res = await getScenes();
+    const scenesWithSteps = await Promise.all(
+      res.data.map(async (scene) => {
+        try {
+          const stepsRes = await getSceneSteps(scene.id);
+          return { ...scene, stepCount: stepsRes.data.length };
+        } catch {
+          return { ...scene, stepCount: 0 };
+        }
+      })
+    );
+    scenes.value = scenesWithSteps;
+  } catch (e) {
+    ElMessage.error('加载场景列表失败');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function handleSearch() {
+}
+
+function handleCategoryChange() {
+}
+
+function enterScene(scene) {
+  pendingScene.value = scene;
+  selectedServerId.value = diagnoseStore.selectedServerId || '';
+  showServerDialog.value = true;
+}
+
+async function confirmEnterScene() {
+  if (!selectedServerId.value || !pendingScene.value) return;
+
+  try {
+    const stepsRes = await getSceneSteps(pendingScene.value.id);
+    const sceneWithSteps = {
+      ...pendingScene.value,
+      steps: stepsRes.data
+    };
+
+    diagnoseStore.initScene(sceneWithSteps, selectedServerId.value);
+
+    showServerDialog.value = false;
+    router.push(`/scenes/${pendingScene.value.id}/diagnose`);
+  } catch (e) {
+    ElMessage.error('加载场景步骤失败');
+  }
+}
+
+onMounted(() => {
+  fetchScenes();
+  serverStore.fetchServers();
+});
+</script>
+
+<style scoped>
+.scene-card {
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  height: 100%;
+}
+
+.scene-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+
+.scene-card-header {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scene-card-body {
+  padding: 16px;
+}
+
+.scene-title {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #303133;
+  line-height: 1.4;
+}
+
+.scene-desc {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  color: #909399;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 40px;
+}
+
+.scene-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.step-count {
+  font-size: 12px;
+  color: #909399;
+}
+
+.scene-business {
+  margin: 0;
+  font-size: 12px;
+  color: #606266;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.scene-business .el-icon {
+  flex-shrink: 0;
+}
+</style>

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -38,40 +38,40 @@ INSERT INTO diagnose_scene (name, description, category, business_scenario, icon
 INSERT INTO diagnose_scene (name, description, category, business_scenario, icon, sort_order, enabled, created_at, updated_at) VALUES ('类冲突排查', '排查类加载和类冲突问题', 'CLASSLOADER', 'ClassNotFoundException、NoSuchMethodError', 'Search', 8, TRUE, NOW(), NOW());
 
 -- 场景 1 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (1, 1, '检查死锁线程', '检测 JVM 中是否存在死锁线程', 'thread -b', '如果发现死锁，继续下一步查看 CPU 热点，或查看线程栈', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (1, 2, 'TOP 5 CPU 活跃线程', '查看 CPU 占用最高的 5 个线程', 'thread -n 5', '记录 CPU 最高的线程 ID，填入下一步', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (1, 3, '查看具体线程栈', '查看指定线程的完整堆栈信息', 'thread {threadId}', '', FALSE, 10000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (1, 1, '检查死锁线程', '检测 JVM 中是否存在死锁线程', 'thread -b', '如果发现死锁，继续下一步查看 CPU 热点，或查看线程栈', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (1, 2, 'TOP 5 CPU 活跃线程', '查看 CPU 占用最高的 5 个线程', 'thread -n 5', '记录 CPU 最高的线程 ID，填入下一步', FALSE, 10000, '[{"variable":"threadId","jsonPath":"$[0].id","description":"从 thread -n 5 结果中提取第一个线程的 ID"}]', NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (1, 3, '查看具体线程栈', '查看指定线程的完整堆栈信息', 'thread {threadId}', '', FALSE, 10000, NULL, NOW(), NOW());
 
 -- 场景 2 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (2, 1, '找出 CPU 最高的线程', '查看 CPU 占用最高的 5 个线程', 'thread -n 5', '记录 CPU 最高的线程 ID，填入下一步', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (2, 2, '查看线程栈', '查看指定线程的完整堆栈信息', 'thread {threadId}', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (2, 3, '查看 JVM 概览', '查看 JVM 运行概览', 'dashboard -n 1', '', FALSE, 15000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (2, 1, '找出 CPU 最高的线程', '查看 CPU 占用最高的 5 个线程', 'thread -n 5', '记录 CPU 最高的线程 ID，填入下一步', FALSE, 10000, '[{"variable":"threadId","jsonPath":"$[0].id","description":"从 thread -n 5 结果中提取第一个线程的 ID"}]', NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (2, 2, '查看线程栈', '查看指定线程的完整堆栈信息', 'thread {threadId}', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (2, 3, '查看 JVM 概览', '查看 JVM 运行概览', 'dashboard -n 1', '', FALSE, 15000, NULL, NOW(), NOW());
 
 -- 场景 3 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (3, 1, '查看内存区使用情况', '查看各内存区使用情况', 'memory', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (3, 2, '查看堆中大对象', '查看堆内存中占用最大的 10 个对象', 'heapdump --live', '', FALSE, 15000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (3, 3, '查看类加载信息', '查看指定类的加载信息', 'sc -d {className}', '', FALSE, 10000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (3, 1, '查看内存区使用情况', '查看各内存区使用情况', 'memory', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (3, 2, '查看堆中大对象', '查看堆内存中占用最大的 10 个对象', 'heapdump --live', '', FALSE, 15000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (3, 3, '查看类加载信息', '查看指定类的加载信息', 'sc -d {className}', '', FALSE, 10000, NULL, NOW(), NOW());
 
 -- 场景 4 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (4, 1, '查看内存区', '查看各内存区使用情况', 'memory', '', FALSE, 10000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (4, 1, '查看内存区', '查看各内存区使用情况', 'memory', '', FALSE, 10000, NULL, NOW(), NOW());
 
 -- 场景 5 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (5, 1, 'JVM 概览', '查看 JVM 运行概览', 'dashboard -n 1', '', FALSE, 15000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (5, 2, 'JVM 参数', '查看 JVM 参数配置', 'vmoption', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (5, 3, '系统环境变量', '查看系统环境变量', 'sysenv', '', FALSE, 10000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (5, 1, 'JVM 概览', '查看 JVM 运行概览', 'dashboard -n 1', '', FALSE, 15000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (5, 2, 'JVM 参数', '查看 JVM 参数配置', 'vmoption', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (5, 3, '系统环境变量', '查看系统环境变量', 'sysenv', '', FALSE, 10000, NULL, NOW(), NOW());
 
 -- 场景 6 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (6, 1, '确认类已加载', '确认指定类已加载', 'sc -d {className}', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (6, 2, '追踪方法调用路径', '追踪方法调用路径和耗时', 'trace {className} {methodName} -n 5', '', TRUE, 30000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (6, 3, '观察方法入参和返回值', '观察方法入参和返回值', 'watch {className} {methodName} \'{params, returnObj, throwExp}\' -n 5 -x 2', '', TRUE, 30000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (6, 1, '确认类已加载', '确认指定类已加载', 'sc -d {className}', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (6, 2, '追踪方法调用路径', '追踪方法调用路径和耗时', 'trace {className} {methodName} -n 5', '', TRUE, 30000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (6, 3, '观察方法入参和返回值', '观察方法入参和返回值', 'watch {className} {methodName} \'{params, returnObj, throwExp}\' -n 5 -x 2', '', TRUE, 30000, NULL, NOW(), NOW());
 
 -- 场景 7 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (7, 1, '确认类已加载', '确认指定类已加载', 'sc -d {className}', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (7, 2, '监控方法调用统计', '监控方法调用统计', 'monitor {className} {methodName} -n 10', '', TRUE, 60000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (7, 3, '查看方法调用路径', '查看方法调用路径', 'stack {className} {methodName} -n 5', '', TRUE, 30000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (7, 1, '确认类已加载', '确认指定类已加载', 'sc -d {className}', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (7, 2, '监控方法调用统计', '监控方法调用统计', 'monitor {className} {methodName} -n 10', '', TRUE, 60000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (7, 3, '查看方法调用路径', '查看方法调用路径', 'stack {className} {methodName} -n 5', '', TRUE, 30000, NULL, NOW(), NOW());
 
 -- 场景 8 步骤
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (8, 1, '查看类加载信息', '查看指定类的加载信息', 'sc -d {className}', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (8, 2, '查看 ClassLoader 继承树', '查看 ClassLoader 继承树', 'classloader -t', '', FALSE, 10000, NOW(), NOW());
-INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, created_at, updated_at) VALUES (8, 3, '反编译查看源码', '反编译指定类查看源码', 'jad {className}', '', FALSE, 15000, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (8, 1, '查看类加载信息', '查看指定类的加载信息', 'sc -d {className}', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (8, 2, '查看 ClassLoader 继承树', '查看 ClassLoader 继承树', 'classloader -t', '', FALSE, 10000, NULL, NOW(), NOW());
+INSERT INTO scene_step (scene_id, step_order, title, description, command, expected_hint, continuous, max_exec_time, extract_rules, created_at, updated_at) VALUES (8, 3, '反编译查看源码', '反编译指定类查看源码', 'jad {className}', '', FALSE, 15000, NULL, NOW(), NOW());
 


### PR DESCRIPTION
- 新增 diagnose store：支持变量缓存、JSONPath 提取、命令预填
- 新增 SceneList.vue：按分类卡片展示场景 + 业务场景检索
- 新增 SceneDiagnose.vue：步骤列表 + 执行 + 变量预填 UI
- 添加 jsonpath-plus 依赖
- 添加场景相关 API 调用
- 更新路由配置，添加 /scenes 和 /scenes/:id/diagnose
- 注册 Element Plus 图标
- 更新 PRD 第二阶段状态为已完成
