### PR TITLE
[P1] 优化角色权限校验，减少数据库查询

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -92,7 +92,7 @@ Set-Cookie: zhenduanqi_token=xxxx; HttpOnly; SameSite=Strict; Path=/api; Max-Age
 **拦截器层（粗粒度）：**
 - `POST /api/auth/login` → 公开，不校验
 - `/api/**` → 必须已认证（存在有效的 JWT Token）
-- 拦截器负责：Token 解析、校验、设置 `SecurityContext`
+- 拦截器负责：Token 解析、校验、设置 `request.setAttribute("username")` 和 `request.setAttribute("userRoles")`（用户角色集合），**一次性查询用户和角色信息**
 
 **注解层（细粒度）：**
 ```java
@@ -100,6 +100,7 @@ Set-Cookie: zhenduanqi_token=xxxx; HttpOnly; SameSite=Strict; Path=/api; Max-Age
 @RequireRole({OPERATOR, ADMIN})        // 操作员和管理员
 // 不加注解 → 任何已认证用户可访问
 ```
+- `RoleAspect` 直接从 `request.getAttribute("userRoles")` 读取用户角色集合，**避免重复查询数据库**，优化性能
 
 **角色定义：**
 | 角色 | 编码 | 权限范围 |

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,9 @@
+解决 #28。
+
+实现内容：
+- 前端安装 jsonpath-plus 库
+- 场景步骤 extract_rules 字段支持 JSONPath 变量提取
+- 变量缓存到 diagnose store 的 variables Map
+- 后续步骤占位符自动填充变量值
+- 支持用户修改预填值后再执行
+- 开始新诊断清空变量缓存

--- a/src/main/java/com/zhenduanqi/aspect/RoleAspect.java
+++ b/src/main/java/com/zhenduanqi/aspect/RoleAspect.java
@@ -1,9 +1,6 @@
 package com.zhenduanqi.aspect;
 
 import com.zhenduanqi.annotation.RequireRole;
-import com.zhenduanqi.entity.SysRole;
-import com.zhenduanqi.entity.SysUser;
-import com.zhenduanqi.repository.SysUserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -17,19 +14,12 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Arrays;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Aspect
 @Component
 public class RoleAspect {
 
     private static final Logger log = LoggerFactory.getLogger(RoleAspect.class);
-
-    private final SysUserRepository userRepository;
-
-    public RoleAspect(SysUserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
 
     @Around("@annotation(com.zhenduanqi.annotation.RequireRole)")
     public Object checkRole(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -49,16 +39,14 @@ public class RoleAspect {
             return null;
         }
 
-        SysUser user = userRepository.findByUsername(username).orElse(null);
-        if (user == null) {
+        // 直接从 request attribute 读取角色集合
+        @SuppressWarnings("unchecked")
+        Set<String> userRoles = (Set<String>) attrs.getRequest().getAttribute("userRoles");
+        if (userRoles == null) {
             attrs.getResponse().setStatus(403);
             attrs.getResponse().getWriter().write("{\"error\":\"用户不存在\"}");
             return null;
         }
-
-        Set<String> userRoles = user.getRoles().stream()
-                .map(SysRole::getRoleCode)
-                .collect(Collectors.toSet());
 
         boolean hasRole = Arrays.stream(allowedRoles).anyMatch(userRoles::contains);
         if (!hasRole) {

--- a/src/main/java/com/zhenduanqi/config/AuthInterceptor.java
+++ b/src/main/java/com/zhenduanqi/config/AuthInterceptor.java
@@ -1,5 +1,8 @@
 package com.zhenduanqi.config;
 
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
 import com.zhenduanqi.service.AuthService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,15 +12,20 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(AuthInterceptor.class);
 
     private final AuthService authService;
+    private final SysUserRepository userRepository;
 
-    public AuthInterceptor(AuthService authService) {
+    public AuthInterceptor(AuthService authService, SysUserRepository userRepository) {
         this.authService = authService;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -41,6 +49,16 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         log.debug("认证通过: username={}, path={}", username, path);
         request.setAttribute("username", username);
+        
+        // 一并查询用户角色并放入 request attribute
+        SysUser user = userRepository.findByUsername(username).orElse(null);
+        if (user != null) {
+            Set<String> userRoles = user.getRoles().stream()
+                    .map(SysRole::getRoleCode)
+                    .collect(Collectors.toSet());
+            request.setAttribute("userRoles", userRoles);
+        }
+        
         return true;
     }
 

--- a/src/test/java/com/zhenduanqi/aspect/RoleAspectLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/aspect/RoleAspectLoggingTest.java
@@ -54,18 +54,12 @@ class RoleAspectLoggingTest {
     void insufficientPermissions_logsWarn() throws Throwable {
         ListAppender<ILoggingEvent> appender = createListAppender();
         try {
-            RoleAspect roleAspect = new RoleAspect(userRepository);
+            RoleAspect roleAspect = new RoleAspect();
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
             request.setAttribute("username", "operator");
+            request.setAttribute("userRoles", Set.of("OPERATOR"));
             RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
-
-            SysRole operatorRole = new SysRole();
-            operatorRole.setRoleCode("OPERATOR");
-            SysUser user = new SysUser();
-            user.setUsername("operator");
-            user.setRoles(Set.of(operatorRole));
-            when(userRepository.findByUsername("operator")).thenReturn(Optional.of(user));
 
             when(joinPoint.getSignature()).thenReturn(signature);
             when(signature.getMethod()).thenReturn(

--- a/src/test/java/com/zhenduanqi/aspect/RoleAspectTest.java
+++ b/src/test/java/com/zhenduanqi/aspect/RoleAspectTest.java
@@ -34,26 +34,22 @@ class RoleAspectTest {
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
 
-    private void setUpRequest(String username) {
-        roleAspect = new RoleAspect(userRepository);
+    private void setUpRequest(String username, Set<String> userRoles) {
+        roleAspect = new RoleAspect();
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
         if (username != null) {
             request.setAttribute("username", username);
+        }
+        if (userRoles != null) {
+            request.setAttribute("userRoles", userRoles);
         }
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
     }
 
     @Test
     void adminUser_onAdminEndpoint_methodProceeds() throws Throwable {
-        SysRole adminRole = new SysRole();
-        adminRole.setRoleCode("ADMIN");
-        SysUser user = new SysUser();
-        user.setUsername("admin");
-        user.setRoles(Set.of(adminRole));
-        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
-
-        setUpRequest("admin");
+        setUpRequest("admin", Set.of("ADMIN"));
         when(joinPoint.getSignature()).thenReturn(signature);
         when(signature.getMethod()).thenReturn(
                 RoleAspectTest.class.getDeclaredMethod("adminOnlyEndpoint"));
@@ -67,14 +63,7 @@ class RoleAspectTest {
 
     @Test
     void operatorUser_onAdminEndpoint_returns403() throws Throwable {
-        SysRole operatorRole = new SysRole();
-        operatorRole.setRoleCode("OPERATOR");
-        SysUser user = new SysUser();
-        user.setUsername("operator");
-        user.setRoles(Set.of(operatorRole));
-        when(userRepository.findByUsername("operator")).thenReturn(Optional.of(user));
-
-        setUpRequest("operator");
+        setUpRequest("operator", Set.of("OPERATOR"));
         when(joinPoint.getSignature()).thenReturn(signature);
         when(signature.getMethod()).thenReturn(
                 RoleAspectTest.class.getDeclaredMethod("adminOnlyEndpoint"));
@@ -88,7 +77,7 @@ class RoleAspectTest {
 
     @Test
     void unauthenticatedUser_onSecuredEndpoint_returns401() throws Throwable {
-        setUpRequest(null);
+        setUpRequest(null, null);
         when(joinPoint.getSignature()).thenReturn(signature);
         when(signature.getMethod()).thenReturn(
                 RoleAspectTest.class.getDeclaredMethod("adminOnlyEndpoint"));

--- a/src/test/java/com/zhenduanqi/config/AuthInterceptorLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/config/AuthInterceptorLoggingTest.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class AuthInterceptorLoggingTest {
@@ -49,7 +49,7 @@ class AuthInterceptorLoggingTest {
         SysUser adminUser = new SysUser();
         adminUser.setUsername("admin");
         adminUser.setRoles(Set.of(adminRole));
-        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(adminUser));
+        lenient().when(userRepository.findByUsername("admin")).thenReturn(Optional.of(adminUser));
     }
 
     private ListAppender<ILoggingEvent> createListAppender() {

--- a/src/test/java/com/zhenduanqi/config/AuthInterceptorLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/config/AuthInterceptorLoggingTest.java
@@ -4,6 +4,8 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
 import com.zhenduanqi.repository.SysUserRepository;
 import com.zhenduanqi.service.AuthService;
 import jakarta.servlet.http.Cookie;
@@ -18,8 +20,11 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthInterceptorLoggingTest {
@@ -36,7 +41,15 @@ class AuthInterceptorLoggingTest {
         TokenBlacklist tokenBlacklist = new TokenBlacklist();
         LoginRateLimiter rateLimiter = new LoginRateLimiter();
         AuthService authService = new AuthService(userRepository, new BCryptPasswordEncoder(), jwtUtil, tokenBlacklist, rateLimiter);
-        interceptor = new AuthInterceptor(authService);
+        interceptor = new AuthInterceptor(authService, userRepository);
+        
+        // 模拟用户数据
+        SysRole adminRole = new SysRole();
+        adminRole.setRoleCode("ADMIN");
+        SysUser adminUser = new SysUser();
+        adminUser.setUsername("admin");
+        adminUser.setRoles(Set.of(adminRole));
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(adminUser));
     }
 
     private ListAppender<ILoggingEvent> createListAppender() {


### PR DESCRIPTION
## 变更内容

解决 issue #14：优化角色权限校验，减少每次请求的数据库查询

### 变更详情：
- **AuthInterceptor.java**：在验证 Token 后一并查询用户角色，并将角色集合放入 request attribute ()
- **RoleAspect.java**：直接从 request attribute 读取用户角色集合，不再查询数据库
- **PRD.md**：更新权限模块描述，记录这次性能优化
- **相关测试**：更新测试以适配代码变更

### 性能改进：
- 每次请求从需要 2 次数据库查询（AuthInterceptor 验证用户 + RoleAspect 查询角色）优化为 1 次查询
- 对于高频 API（如 ），显著减少数据库负载

### 验收标准：
- ✅ RoleAspect 不再直接查询数据库获取角色
- ✅ 权限校验功能与当前行为完全一致
- ✅ 相关测试通过

## 关联
Closes #14