### PR TITLE
[P1] fix(audit): 审计日志保存失败不影响业务逻辑 (#71)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -147,6 +147,7 @@ public ResponseEntity<?> login(@RequestBody LoginRequest request, ...) {
 - 从 DTO 对象中自动提取 `username` 字段（用于登录场景，当 request attribute 中无 username 时）
 - 使用正则表达式匹配并脱敏敏感字段（password、token）
 - 支持嵌套 JSON 结构的参数序列化
+- **异常保护**：finally 块中的 save() 操作必须用 try-catch 包裹，审计日志保存失败不应影响业务逻辑（仅记录 ERROR 日志）
 
 **记录内容（高可审计要求）：**
 | 字段 | 内容 | 脱敏规则 |

--- a/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
+++ b/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
@@ -89,7 +89,11 @@ public class AuditLogAspect {
             throw e;
         } finally {
             auditEntry.setDurationMs(System.currentTimeMillis() - start);
-            auditLogRepository.save(auditEntry);
+            try {
+                auditLogRepository.save(auditEntry);
+            } catch (Exception e) {
+                log.error("审计日志保存失败: action={}, user={}, error={}", auditEntry.getAction(), auditEntry.getUsername(), e.getMessage());
+            }
         }
     }
 

--- a/src/test/java/com/zhenduanqi/aspect/AuditLogAspectTest.java
+++ b/src/test/java/com/zhenduanqi/aspect/AuditLogAspectTest.java
@@ -290,4 +290,18 @@ class AuditLogAspectTest {
             removeAppender(appender);
         }
     }
+
+    @Test
+    void auditLogSaveFailure_doesNotAffectBusinessLogic() throws Throwable {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getMethod()).thenReturn(
+                AuditLogAspectTest.class.getDeclaredMethod("dummyDiagnoseMethod"));
+        when(joinPoint.getArgs()).thenReturn(new Object[]{"cmd1", "server-1"});
+        when(joinPoint.proceed()).thenReturn("success");
+        doThrow(new RuntimeException("数据库连接失败")).when(auditLogRepository).save(any());
+
+        Object result = aspect.logAround(joinPoint);
+
+        assertThat(result).isEqualTo("success");
+    }
 }


### PR DESCRIPTION
## What

修复 AuditLogAspect 的 finally 块中 auditLogRepository.save() 没有异常保护的问题。

## Why

当审计日志保存失败时（如数据库连接失败），异常会传播到 Controller 层，导致业务逻辑失败。例如：
- 登录成功后，审计日志保存失败会导致 Internal Server Error
- 用户无法正常完成业务操作

## How

1. 在 finally 块中的 save() 操作添加 try-catch 包裹
2. 审计日志保存失败时仅记录 ERROR 日志，不抛出异常
3. 同步更新 PRD.md 中的实现细节说明

## Test

- 新增测试用例 `auditLogSaveFailure_doesNotAffectBusinessLogic` 验证审计日志保存失败时业务逻辑不受影响
- 所有 AuditLogAspectTest 测试通过

Closes #71