### PR TITLE
[P2] ArthasSessionService 日志埋点 (#76)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -253,8 +253,8 @@ public void doFilter(ServletRequest request, ServletResponse response, FilterCha
 | ArthasExecuteService | INFO | 命令执行完成（含结果状态、耗时） | ✅ 已实现 |
 | ArthasHttpClient | INFO | Arthas API 请求（含服务器名、命令） | ✅ 已实现 |
 | ArthasHttpClient | WARN | 连接检测失败 | ✅ 已实现 |
-| ArthasSessionService | INFO | 会话创建/关闭/超时清理 | TODO 待P2实现 |
-| ArthasSessionService | WARN | 孤儿会话检测与清理 | TODO 待P2实现 |
+| ArthasSessionService | INFO | 会话创建/关闭/超时清理 | ✅ 已实现 |
+| ArthasSessionService | WARN | 孤儿会话检测与清理 | ✅ 已实现 |
 | JwtUtil | WARN | Token 校验异常（不输出 Token 原文） | ✅ 已实现 |
 | ArthasServerService | INFO | 服务器 CRUD 操作 | ✅ 已实现 |
 | UserService | INFO | 用户 CRUD 操作、密码重置 | ✅ 已实现 |
@@ -1025,7 +1025,7 @@ zhenduanqi/
 | **SceneService** | 场景步骤编排、命令模板占位符处理 | P1 |
 | **前端渲染器** | 各 type 渲染组件的输入输出 | P1 | ✅ 已实现 |
 | **前端 extract_rules** | JSONPath 变量提取逻辑 | P1 |
-| **ArthasSessionService** | 会话创建/关闭、L1-L4 安全机制、孤儿清理 | P2 |
+| **ArthasSessionService** | 会话创建/关闭、L1-L4 安全机制、孤儿清理 | P2 | ✅ 已实现 |
 | **ArthasHttpClient 异步** | async_exec/pull_results/interrupt_job | P2 |
 | **前端 API 层** | Axios 拦截器、401 重定向 | P0 |
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Arthas 诊断工具</title>
-  <script type="module" crossorigin src="/assets/index-BSE3b556.js"></script>
+  <script type="module" crossorigin src="/assets/index-DROPMEIO.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DGByZTGm.css">
 </head>
 <body>

--- a/src/test/java/com/zhenduanqi/controller/AuditLogControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/AuditLogControllerTest.java
@@ -1,6 +1,9 @@
 package com.zhenduanqi.controller;
 
 import com.zhenduanqi.entity.SysAuditLog;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
 import com.zhenduanqi.service.AuditLogService;
 import com.zhenduanqi.service.AuthService;
 import org.junit.jupiter.api.Test;
@@ -12,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
@@ -30,6 +34,9 @@ class AuditLogControllerTest {
     @MockBean
     private AuthService authService;
 
+    @MockBean
+    private SysUserRepository userRepository;
+
     @Test
     void query_withDefaultParams_returnsPage() throws Exception {
         SysAuditLog log = new SysAuditLog();
@@ -39,7 +46,14 @@ class AuditLogControllerTest {
         log.setResult("SUCCESS");
         log.setDurationMs(100L);
 
+        SysUser adminUser = new SysUser();
+        adminUser.setUsername("admin");
+        SysRole adminRole = new SysRole();
+        adminRole.setRoleCode("ADMIN");
+        adminUser.setRoles(Set.of(adminRole));
+
         when(authService.validateToken("valid-jwt")).thenReturn("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(java.util.Optional.of(adminUser));
         when(auditLogService.query(any(), any(), any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 20), 1));
 

--- a/src/test/java/com/zhenduanqi/controller/AuthControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/AuthControllerTest.java
@@ -2,6 +2,9 @@ package com.zhenduanqi.controller;
 
 import com.zhenduanqi.dto.LoginRequest;
 import com.zhenduanqi.dto.LoginResponse;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
 import com.zhenduanqi.service.AuthService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
@@ -12,6 +15,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -31,7 +36,19 @@ class AuthControllerTest {
     @MockBean
     private AuthService authService;
 
+    @MockBean
+    private SysUserRepository userRepository;
+
     private final Cookie validCookie = new Cookie("zhenduanqi_token", "valid-jwt");
+
+    private SysUser createMockUser(String username, String roleCode) {
+        SysUser user = new SysUser();
+        user.setUsername(username);
+        SysRole role = new SysRole();
+        role.setRoleCode(roleCode);
+        user.setRoles(Set.of(role));
+        return user;
+    }
 
     @Test
     void login_withValidCredentials_returns200() throws Exception {
@@ -78,6 +95,7 @@ class AuthControllerTest {
     @Test
     void logout_withValidToken_returns200() throws Exception {
         when(authService.validateToken("valid-jwt")).thenReturn("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(java.util.Optional.of(createMockUser("admin", "ADMIN")));
 
         mockMvc.perform(post("/api/auth/logout").cookie(validCookie))
                 .andExpect(status().isOk());
@@ -87,6 +105,7 @@ class AuthControllerTest {
     void me_withValidToken_returnsUserInfo() throws Exception {
         when(authService.validateToken("valid-jwt")).thenReturn("admin");
         when(authService.getUserRole("admin")).thenReturn("ADMIN");
+        when(userRepository.findByUsername("admin")).thenReturn(java.util.Optional.of(createMockUser("admin", "ADMIN")));
 
         mockMvc.perform(get("/api/auth/me").cookie(validCookie))
                 .andExpect(status().isOk())

--- a/src/test/java/com/zhenduanqi/controller/CommandGuardControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/CommandGuardControllerTest.java
@@ -1,6 +1,9 @@
 package com.zhenduanqi.controller;
 
 import com.zhenduanqi.entity.CommandGuardRule;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
 import com.zhenduanqi.service.AuthService;
 import com.zhenduanqi.service.CommandGuardService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -34,11 +38,24 @@ class CommandGuardControllerTest {
     @MockBean
     private AuthService authService;
 
+    @MockBean
+    private SysUserRepository userRepository;
+
     private final Cookie adminCookie = new Cookie("zhenduanqi_token", "admin-jwt");
+
+    private SysUser createMockUser(String username, String roleCode) {
+        SysUser user = new SysUser();
+        user.setUsername(username);
+        SysRole role = new SysRole();
+        role.setRoleCode(roleCode);
+        user.setRoles(Set.of(role));
+        return user;
+    }
 
     @Test
     void getRules_returnsRuleList() throws Exception {
         when(authService.validateToken("admin-jwt")).thenReturn("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(java.util.Optional.of(createMockUser("admin", "ADMIN")));
         CommandGuardRule rule = new CommandGuardRule();
         rule.setId(1L);
         rule.setRuleType("BLACKLIST");
@@ -55,6 +72,7 @@ class CommandGuardControllerTest {
     @Test
     void addRule_returnsCreatedRule() throws Exception {
         when(authService.validateToken("admin-jwt")).thenReturn("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(java.util.Optional.of(createMockUser("admin", "ADMIN")));
         CommandGuardRule created = new CommandGuardRule();
         created.setId(1L);
         created.setRuleType("BLACKLIST");
@@ -75,6 +93,7 @@ class CommandGuardControllerTest {
     @Test
     void deleteRule_returnsNoContent() throws Exception {
         when(authService.validateToken("admin-jwt")).thenReturn("admin");
+        when(userRepository.findByUsername("admin")).thenReturn(java.util.Optional.of(createMockUser("admin", "ADMIN")));
 
         mockMvc.perform(delete("/api/command-guard/rules/1").cookie(adminCookie))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/zhenduanqi/service/ArthasSessionServiceLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasSessionServiceLoggingTest.java
@@ -1,0 +1,207 @@
+package com.zhenduanqi.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.zhenduanqi.client.ArthasHttpClient;
+import com.zhenduanqi.dto.ArthasSessionDTO;
+import com.zhenduanqi.dto.CreateSessionRequest;
+import com.zhenduanqi.entity.ArthasSession;
+import com.zhenduanqi.model.ArthasApiResponse;
+import com.zhenduanqi.model.SessionInfo;
+import com.zhenduanqi.model.ServerInfo;
+import com.zhenduanqi.repository.ArthasServerRepository;
+import com.zhenduanqi.repository.ArthasSessionRepository;
+import com.zhenduanqi.repository.CommandGuardRuleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArthasSessionServiceLoggingTest {
+
+    @Mock
+    private ArthasSessionRepository sessionRepository;
+    @Mock
+    private ArthasServerService serverService;
+    @Mock
+    private ArthasHttpClient arthasClient;
+    @Mock
+    private CommandGuardRuleRepository ruleRepository;
+    @Mock
+    private CommandGuardService commandGuardService;
+
+    private ArthasSessionService sessionService;
+
+    @BeforeEach
+    void setUp() {
+        sessionService = new ArthasSessionService(
+                sessionRepository, serverService, arthasClient, commandGuardService);
+    }
+
+    private ListAppender<ILoggingEvent> createListAppender() {
+        LoggerContext ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ch.qos.logback.classic.Logger logger = ctx.getLogger(ArthasSessionService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private void removeAppender(ListAppender<ILoggingEvent> appender) {
+        LoggerContext ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ctx.getLogger(ArthasSessionService.class).detachAppender(appender);
+    }
+
+    @Test
+    void createSession_success_logsInfo() {
+        ListAppender<ILoggingEvent> appender = createListAppender();
+        try {
+            ServerInfo serverInfo = new ServerInfo();
+            serverInfo.setId("server1");
+            serverInfo.setName("TestServer");
+
+            when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+            when(commandGuardService.check(anyString())).thenReturn(new CommandGuardService.GuardResult(false, null));
+            when(arthasClient.initSession(serverInfo)).thenReturn(new SessionInfo("arthas-session-1", "consumer-1"));
+
+            ArthasApiResponse apiResponse = new ArthasApiResponse();
+            apiResponse.setState("scheduled");
+            ArthasApiResponse.Body body = new ArthasApiResponse.Body();
+            body.setJobId(1);
+            apiResponse.setBody(body);
+            when(arthasClient.asyncExecuteCommand(any(), anyString(), anyString())).thenReturn(apiResponse);
+            when(sessionRepository.save(any(ArthasSession.class))).thenAnswer(inv -> {
+                ArthasSession s = inv.getArgument(0);
+                s.setId(1L);
+                return s;
+            });
+
+            CreateSessionRequest request = new CreateSessionRequest();
+            request.setServerId("server1");
+            request.setCommand("thread -n 5");
+            request.setSceneId(1L);
+            request.setStepId(1L);
+
+            sessionService.createSession(request, "admin");
+
+            List<ILoggingEvent> events = appender.list;
+            assertThat(events.stream().anyMatch(e ->
+                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("创建 Arthas 会话"))).isTrue();
+        } finally {
+            removeAppender(appender);
+        }
+    }
+
+    @Test
+    void closeSession_logsInfo() {
+        ListAppender<ILoggingEvent> appender = createListAppender();
+        try {
+            ServerInfo serverInfo = new ServerInfo();
+            serverInfo.setId("server1");
+
+            ArthasSession session = new ArthasSession();
+            session.setId(1L);
+            session.setServerId("server1");
+            session.setArthasSessionId("arthas-session-1");
+            session.setStatus("ACTIVE");
+
+            when(sessionRepository.findById(1L)).thenReturn(Optional.of(session));
+            when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+            when(arthasClient.executeSystemCommand(any(), anyString(), anyString())).thenReturn(null);
+            when(arthasClient.closeSession(any(), anyString())).thenReturn(true);
+            when(sessionRepository.save(any(ArthasSession.class))).thenReturn(session);
+
+            sessionService.closeSession(1L);
+
+            List<ILoggingEvent> events = appender.list;
+            assertThat(events.stream().anyMatch(e ->
+                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("关闭 Arthas 会话"))).isTrue();
+        } finally {
+            removeAppender(appender);
+        }
+    }
+
+    @Test
+    void interruptJob_logsInfo() {
+        ListAppender<ILoggingEvent> appender = createListAppender();
+        try {
+            ServerInfo serverInfo = new ServerInfo();
+            serverInfo.setId("server1");
+
+            ArthasSession session = new ArthasSession();
+            session.setId(1L);
+            session.setServerId("server1");
+            session.setArthasSessionId("arthas-session-1");
+
+            when(sessionRepository.findById(1L)).thenReturn(Optional.of(session));
+            when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+            when(arthasClient.interruptJob(any(), anyString())).thenReturn(true);
+
+            sessionService.interruptJob(1L);
+
+            List<ILoggingEvent> events = appender.list;
+            assertThat(events.stream().anyMatch(e ->
+                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("中断任务"))).isTrue();
+        } finally {
+            removeAppender(appender);
+        }
+    }
+
+    @Test
+    void cleanupOrphanSessions_logsInfo() {
+        ListAppender<ILoggingEvent> appender = createListAppender();
+        try {
+            ArthasSession orphanSession = new ArthasSession();
+            orphanSession.setId(1L);
+            orphanSession.setServerId("server1");
+            orphanSession.setArthasSessionId("arthas-session-1");
+            orphanSession.setStatus("ACTIVE");
+            orphanSession.setLastActiveAt(LocalDateTime.now().minusMinutes(15));
+
+            when(sessionRepository.findByLastActiveAtBeforeAndStatus(any(LocalDateTime.class), eq("ACTIVE")))
+                    .thenReturn(List.of(orphanSession));
+            when(sessionRepository.findById(1L)).thenReturn(Optional.of(orphanSession));
+            when(serverService.findServerInfoById("server1")).thenReturn(Optional.empty());
+            when(sessionRepository.save(any(ArthasSession.class))).thenReturn(orphanSession);
+
+            sessionService.cleanupOrphanSessions();
+
+            List<ILoggingEvent> events = appender.list;
+            assertThat(events.stream().anyMatch(e ->
+                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("清理孤儿会话完成"))).isTrue();
+        } finally {
+            removeAppender(appender);
+        }
+    }
+
+    @Test
+    void cleanupOrphanSessions_whenEmpty_logsInfo() {
+        ListAppender<ILoggingEvent> appender = createListAppender();
+        try {
+            when(sessionRepository.findByLastActiveAtBeforeAndStatus(any(LocalDateTime.class), eq("ACTIVE")))
+                    .thenReturn(List.of());
+
+            sessionService.cleanupOrphanSessions();
+
+            List<ILoggingEvent> events = appender.list;
+            assertThat(events.stream().anyMatch(e ->
+                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("清理孤儿会话完成"))).isTrue();
+        } finally {
+            removeAppender(appender);
+        }
+    }
+}


### PR DESCRIPTION
解决 #76。

实现内容：
- ArthasSessionService 日志埋点测试 (ArthasSessionServiceLoggingTest)
- 会话创建日志 (INFO): sessionId, serverId, username
- 会话关闭日志 (INFO): sessionId
- 任务中断日志 (INFO): sessionId, result
- 孤儿会话清理日志 (INFO): count
- 更新 PRD.md 日志组件状态

测试覆盖：
- createSession_success_logsInfo
- closeSession_logsInfo
- interruptJob_logsInfo
- cleanupOrphanSessions_logsInfo
- cleanupOrphanSessions_whenEmpty_logsInfo

Closes #76