### PR TITLE
[P1] 导航菜单添加场景列表入口 (#72)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -848,7 +848,7 @@ CREATE TABLE arthas_session (
 ```
 /                          → 重定向到 /scenes
 /login                     → 登录页面
-/scenes                    → 场景列表页（按分类展示所有场景卡片）
+/scenes                    → 场景列表页（按分类展示所有场景卡片）← 导航菜单默认入口
 /scenes/:id/diagnose       → 场景诊断页（步骤列表 + 执行）
 /scenes/manage             → 场景管理页（ADMIN，CRUD场景和步骤）
 /servers                   → 服务器管理页
@@ -858,6 +858,17 @@ CREATE TABLE arthas_session (
 /command-guard             → 高危命令规则页（ADMIN）
 /sessions                  → 活跃会话管理页（ADMIN，查看和清理Arthas会话）
 ```
+
+**导航菜单：** 登录后顶部导航栏包含以下菜单项：
+- 场景列表（/scenes）— 默认入口
+- 执行诊断（/diagnose）
+- 服务器管理（/servers）— ADMIN
+- 用户管理（/users）— ADMIN
+- 审计日志（/audit-logs）— ADMIN
+- 命令守卫（/command-guard）— ADMIN
+- 会话管理（/sessions）— ADMIN
+
+**登录后默认跳转：** 已登录用户访问 /login 会重定向到 /scenes
 
 ### 项目结构（最终态）
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@
         style="background: transparent; border-bottom: none"
         active-text-color="#fff"
       >
+        <el-menu-item index="/scenes" style="color: white">场景列表</el-menu-item>
         <el-menu-item index="/diagnose" style="color: white">执行诊断</el-menu-item>
         <el-menu-item index="/servers" v-if="userStore.role === 'ADMIN'" style="color: white">
           服务器管理

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -80,7 +80,7 @@ router.beforeEach(async (to, from, next) => {
 
   if (to.path === '/login') {
     if (userStore.isLoggedIn) {
-      next('/diagnose');
+      next('/scenes');
     } else {
       next();
     }

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -68,7 +68,7 @@ async function handleLogin() {
   try {
     await userStore.login(form.username, form.password);
     ElMessage.success('登录成功');
-    router.push('/diagnose');
+    router.push('/scenes');
   } catch (e) {
     ElMessage.error(e.response?.data?.error || '登录失败');
   } finally {


### PR DESCRIPTION
## 修复内容

修复 Issue #72：导航菜单缺少场景诊断入口

### 改动点

1. **App.vue**：在顶部导航菜单添加场景列表菜单项（路由：/scenes），放在首位作为默认入口
2. **router/index.js**：登录后已认证用户访问 /login 时重定向到 /scenes（与根路由一致）
3. **Login.vue**：登录成功后跳转到 /scenes（与 router 重定向目标一致）
4. **PRD.md**：更新前端页面结构文档，明确导航菜单和默认跳转

### 验证方式

1. 登录系统，顶部导航栏应显示场景列表入口
2. 点击场景列表应正确跳转到 /scenes 页面
3. 登录成功后应自动跳转到 /scenes 页面

Closes #72