### PR TITLE
test: add missing tests for ArthasSessionService and ArthasSessionController (#31)

### DIFF
--- a/src/test/java/com/zhenduanqi/controller/ArthasSessionControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/ArthasSessionControllerTest.java
@@ -1,0 +1,289 @@
+package com.zhenduanqi.controller;
+
+import com.zhenduanqi.aspect.RoleAspect;
+import com.zhenduanqi.dto.ArthasSessionDTO;
+import com.zhenduanqi.dto.CreateSessionRequest;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.model.ArthasResult;
+import com.zhenduanqi.repository.SysUserRepository;
+import com.zhenduanqi.service.ArthasSessionService;
+import com.zhenduanqi.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ArthasSessionController.class)
+@Import(RoleAspect.class)
+@EnableAspectJAutoProxy
+class ArthasSessionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ArthasSessionService sessionService;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private SysUserRepository userRepository;
+
+    private final Cookie adminCookie = new Cookie("zhenduanqi_token", "admin-jwt");
+    private final Cookie operatorCookie = new Cookie("zhenduanqi_token", "operator-jwt");
+    private final Cookie readonlyCookie = new Cookie("zhenduanqi_token", "readonly-jwt");
+
+    @BeforeEach
+    void setUp() {
+        SysRole adminRole = new SysRole();
+        adminRole.setRoleCode("ADMIN");
+        SysUser adminUser = new SysUser();
+        adminUser.setUsername("admin");
+        adminUser.setRoles(Set.of(adminRole));
+
+        SysRole operatorRole = new SysRole();
+        operatorRole.setRoleCode("OPERATOR");
+        SysUser operatorUser = new SysUser();
+        operatorUser.setUsername("operator");
+        operatorUser.setRoles(Set.of(operatorRole));
+
+        SysRole readonlyRole = new SysRole();
+        readonlyRole.setRoleCode("READONLY");
+        SysUser readonlyUser = new SysUser();
+        readonlyUser.setUsername("readonly");
+        readonlyUser.setRoles(Set.of(readonlyRole));
+
+        when(authService.validateToken("admin-jwt")).thenReturn("admin");
+        when(authService.validateToken("operator-jwt")).thenReturn("operator");
+        when(authService.validateToken("readonly-jwt")).thenReturn("readonly");
+
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByUsername("operator")).thenReturn(Optional.of(operatorUser));
+        when(userRepository.findByUsername("readonly")).thenReturn(Optional.of(readonlyUser));
+    }
+
+    @Test
+    void createSession_withAdminAuth_returns200() throws Exception {
+        CreateSessionRequest req = new CreateSessionRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        ArthasSessionDTO resp = new ArthasSessionDTO();
+        resp.setId(1L);
+        resp.setStatus("ACTIVE");
+        when(sessionService.createSession(any(CreateSessionRequest.class), anyString())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/arthas-sessions")
+                        .cookie(adminCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+
+    @Test
+    void createSession_withOperatorAuth_returns200() throws Exception {
+        CreateSessionRequest req = new CreateSessionRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        ArthasSessionDTO resp = new ArthasSessionDTO();
+        resp.setId(1L);
+        resp.setStatus("ACTIVE");
+        when(sessionService.createSession(any(CreateSessionRequest.class), anyString())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/arthas-sessions")
+                        .cookie(operatorCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+
+    @Test
+    void createSession_withReadonlyAuth_returns403() throws Exception {
+        CreateSessionRequest req = new CreateSessionRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        mockMvc.perform(post("/api/arthas-sessions")
+                        .cookie(readonlyCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createSession_withoutAuth_returns401() throws Exception {
+        CreateSessionRequest req = new CreateSessionRequest();
+        req.setServerId("server-1");
+        req.setCommand("thread");
+
+        mockMvc.perform(post("/api/arthas-sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getActiveSessions_withAdminAuth_returns200() throws Exception {
+        ArthasSessionDTO session1 = new ArthasSessionDTO();
+        session1.setId(1L);
+        session1.setStatus("ACTIVE");
+
+        ArthasSessionDTO session2 = new ArthasSessionDTO();
+        session2.setId(2L);
+        session2.setStatus("ACTIVE");
+
+        when(sessionService.getActiveSessions(anyString())).thenReturn(List.of(session1, session2));
+
+        mockMvc.perform(get("/api/arthas-sessions")
+                        .cookie(adminCookie)
+                        .param("serverId", "server-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    void getActiveSessions_withOperatorAuth_returns200() throws Exception {
+        ArthasSessionDTO session = new ArthasSessionDTO();
+        session.setId(1L);
+        session.setStatus("ACTIVE");
+
+        when(sessionService.getActiveSessions(anyString())).thenReturn(List.of(session));
+
+        mockMvc.perform(get("/api/arthas-sessions")
+                        .cookie(operatorCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getActiveSessions_withReadonlyAuth_returns200() throws Exception {
+        ArthasSessionDTO session = new ArthasSessionDTO();
+        session.setId(1L);
+        session.setStatus("ACTIVE");
+
+        when(sessionService.getActiveSessions(anyString())).thenReturn(List.of(session));
+
+        mockMvc.perform(get("/api/arthas-sessions")
+                        .cookie(readonlyCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getActiveSessions_withoutAuth_returns401() throws Exception {
+        mockMvc.perform(get("/api/arthas-sessions"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void pullResults_withAdminAuth_returns200() throws Exception {
+        ArthasResult result = new ArthasResult();
+        result.setType("thread");
+
+        when(sessionService.pullResults(1L)).thenReturn(List.of(result));
+
+        mockMvc.perform(get("/api/arthas-sessions/1/results")
+                        .cookie(adminCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].type").value("thread"));
+    }
+
+    @Test
+    void pullResults_withOperatorAuth_returns200() throws Exception {
+        ArthasResult result = new ArthasResult();
+        result.setType("thread");
+
+        when(sessionService.pullResults(1L)).thenReturn(List.of(result));
+
+        mockMvc.perform(get("/api/arthas-sessions/1/results")
+                        .cookie(operatorCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void pullResults_withReadonlyAuth_returns403() throws Exception {
+        mockMvc.perform(get("/api/arthas-sessions/1/results")
+                        .cookie(readonlyCookie))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void interrupt_withAdminAuth_returns200() throws Exception {
+        when(sessionService.interruptJob(1L)).thenReturn(true);
+
+        mockMvc.perform(post("/api/arthas-sessions/1/interrupt")
+                        .cookie(adminCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void interrupt_withOperatorAuth_returns200() throws Exception {
+        when(sessionService.interruptJob(1L)).thenReturn(true);
+
+        mockMvc.perform(post("/api/arthas-sessions/1/interrupt")
+                        .cookie(operatorCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void interrupt_withReadonlyAuth_returns403() throws Exception {
+        mockMvc.perform(post("/api/arthas-sessions/1/interrupt")
+                        .cookie(readonlyCookie))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void close_withAdminAuth_returns200() throws Exception {
+        when(sessionService.closeSession(1L)).thenReturn(true);
+
+        mockMvc.perform(post("/api/arthas-sessions/1/close")
+                        .cookie(adminCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void close_withOperatorAuth_returns200() throws Exception {
+        when(sessionService.closeSession(1L)).thenReturn(true);
+
+        mockMvc.perform(post("/api/arthas-sessions/1/close")
+                        .cookie(operatorCookie))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void close_withReadonlyAuth_returns403() throws Exception {
+        mockMvc.perform(post("/api/arthas-sessions/1/close")
+                        .cookie(readonlyCookie))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/zhenduanqi/service/ArthasSessionServiceTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasSessionServiceTest.java
@@ -1,0 +1,305 @@
+package com.zhenduanqi.service;
+
+import com.zhenduanqi.client.ArthasHttpClient;
+import com.zhenduanqi.dto.ArthasSessionDTO;
+import com.zhenduanqi.dto.CreateSessionRequest;
+import com.zhenduanqi.entity.ArthasSession;
+import com.zhenduanqi.model.ArthasApiResponse;
+import com.zhenduanqi.model.ArthasResult;
+import com.zhenduanqi.model.ServerInfo;
+import com.zhenduanqi.model.SessionInfo;
+import com.zhenduanqi.repository.ArthasSessionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArthasSessionServiceTest {
+
+    @Mock
+    private ArthasSessionRepository sessionRepository;
+
+    @Mock
+    private ArthasServerService serverService;
+
+    @Mock
+    private ArthasHttpClient arthasClient;
+
+    @Mock
+    private CommandGuardService commandGuardService;
+
+    private ArthasSessionService sessionService;
+
+    @BeforeEach
+    void setUp() {
+        sessionService = new ArthasSessionService(
+                sessionRepository, serverService, arthasClient, commandGuardService);
+    }
+
+    private ServerInfo createTestServerInfo() {
+        ServerInfo server = new ServerInfo();
+        server.setId("server1");
+        server.setName("Test Server");
+        server.setHost("localhost");
+        server.setHttpPort(8563);
+        return server;
+    }
+
+    @Test
+    void createSession_success() {
+        ServerInfo serverInfo = createTestServerInfo();
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(commandGuardService.check("thread -n 5")).thenReturn(
+                new CommandGuardService.GuardResult(false, null));
+        when(arthasClient.initSession(serverInfo)).thenReturn(
+                new SessionInfo("arthas-session-1", "consumer-1"));
+
+        ArthasApiResponse apiResponse = new ArthasApiResponse();
+        apiResponse.setState("scheduled");
+        ArthasApiResponse.Body body = new ArthasApiResponse.Body();
+        body.setJobId(1);
+        apiResponse.setBody(body);
+        when(arthasClient.asyncExecuteCommand(any(), anyString(), anyString())).thenReturn(apiResponse);
+        when(sessionRepository.save(any(ArthasSession.class))).thenAnswer(inv -> {
+            ArthasSession s = inv.getArgument(0);
+            s.setId(1L);
+            return s;
+        });
+
+        CreateSessionRequest request = new CreateSessionRequest();
+        request.setServerId("server1");
+        request.setCommand("thread -n 5");
+        request.setSceneId(1L);
+        request.setStepId(1L);
+
+        ArthasSessionDTO result = sessionService.createSession(request, "admin");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getServerId()).isEqualTo("server1");
+        assertThat(result.getArthasSessionId()).isEqualTo("arthas-session-1");
+        assertThat(result.getCurrentJobId()).isEqualTo(1);
+        assertThat(result.getStatus()).isEqualTo("ACTIVE");
+        assertThat(result.getUsername()).isEqualTo("admin");
+    }
+
+    @Test
+    void createSession_serverNotFound_throwsException() {
+        when(serverService.findServerInfoById("nonexistent")).thenReturn(Optional.empty());
+
+        CreateSessionRequest request = new CreateSessionRequest();
+        request.setServerId("nonexistent");
+        request.setCommand("thread -n 5");
+
+        assertThatThrownBy(() -> sessionService.createSession(request, "admin"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("未找到服务器");
+    }
+
+    @Test
+    void createSession_commandBlocked_throwsException() {
+        ServerInfo serverInfo = createTestServerInfo();
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(commandGuardService.check("ognl -x 1")).thenReturn(
+                new CommandGuardService.GuardResult(true, "高危命令已被拦截"));
+
+        CreateSessionRequest request = new CreateSessionRequest();
+        request.setServerId("server1");
+        request.setCommand("ognl -x 1");
+
+        assertThatThrownBy(() -> sessionService.createSession(request, "admin"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("命令被拦截");
+    }
+
+    @Test
+    void createSession_initSessionFails_throwsException() {
+        ServerInfo serverInfo = createTestServerInfo();
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(commandGuardService.check("thread -n 5")).thenReturn(
+                new CommandGuardService.GuardResult(false, null));
+        when(arthasClient.initSession(serverInfo)).thenReturn(null);
+
+        CreateSessionRequest request = new CreateSessionRequest();
+        request.setServerId("server1");
+        request.setCommand("thread -n 5");
+
+        assertThatThrownBy(() -> sessionService.createSession(request, "admin"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("初始化 Arthas 会话失败");
+    }
+
+    @Test
+    void getActiveSessions_withServerId_returnsActiveSessions() {
+        ArthasSession session1 = new ArthasSession();
+        session1.setId(1L);
+        session1.setServerId("server1");
+        session1.setStatus("ACTIVE");
+
+        ArthasSession session2 = new ArthasSession();
+        session2.setId(2L);
+        session2.setServerId("server1");
+        session2.setStatus("CLOSED");
+
+        when(sessionRepository.findByServerIdAndStatusOrderByCreatedAtDesc("server1", "ACTIVE"))
+                .thenReturn(List.of(session1));
+
+        List<ArthasSessionDTO> result = sessionService.getActiveSessions("server1");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getActiveSessions_withoutServerId_returnsAllActiveSessions() {
+        ArthasSession session1 = new ArthasSession();
+        session1.setId(1L);
+        session1.setServerId("server1");
+        session1.setStatus("ACTIVE");
+
+        ArthasSession session2 = new ArthasSession();
+        session2.setId(2L);
+        session2.setServerId("server2");
+        session2.setStatus("ACTIVE");
+
+        when(sessionRepository.findByStatusOrderByCreatedAtDesc("ACTIVE"))
+                .thenReturn(List.of(session1, session2));
+
+        List<ArthasSessionDTO> result = sessionService.getActiveSessions(null);
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void pullResults_success() {
+        ArthasSession session = new ArthasSession();
+        session.setId(1L);
+        session.setServerId("server1");
+        session.setArthasSessionId("arthas-session-1");
+        session.setArthasConsumerId("consumer-1");
+
+        ServerInfo serverInfo = createTestServerInfo();
+
+        ArthasResult result1 = new ArthasResult();
+        result1.setType("thread");
+
+        when(sessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(arthasClient.pullResults(serverInfo, "arthas-session-1", "consumer-1"))
+                .thenReturn(List.of(result1));
+        when(sessionRepository.save(any(ArthasSession.class))).thenReturn(session);
+
+        List<ArthasResult> result = sessionService.pullResults(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getType()).isEqualTo("thread");
+        verify(sessionRepository).save(any(ArthasSession.class));
+    }
+
+    @Test
+    void pullResults_sessionNotFound_returnsEmpty() {
+        when(sessionRepository.findById(99L)).thenReturn(Optional.empty());
+
+        List<ArthasResult> result = sessionService.pullResults(99L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void interruptJob_success() {
+        ArthasSession session = new ArthasSession();
+        session.setId(1L);
+        session.setServerId("server1");
+        session.setArthasSessionId("arthas-session-1");
+
+        ServerInfo serverInfo = createTestServerInfo();
+
+        when(sessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(arthasClient.interruptJob(serverInfo, "arthas-session-1")).thenReturn(true);
+
+        boolean result = sessionService.interruptJob(1L);
+
+        assertThat(result).isTrue();
+        verify(arthasClient).interruptJob(serverInfo, "arthas-session-1");
+    }
+
+    @Test
+    void interruptJob_sessionNotFound_returnsFalse() {
+        when(sessionRepository.findById(99L)).thenReturn(Optional.empty());
+
+        boolean result = sessionService.interruptJob(99L);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void closeSession_success() {
+        ArthasSession session = new ArthasSession();
+        session.setId(1L);
+        session.setServerId("server1");
+        session.setArthasSessionId("arthas-session-1");
+        session.setStatus("ACTIVE");
+
+        ServerInfo serverInfo = createTestServerInfo();
+
+        when(sessionRepository.findById(1L)).thenReturn(Optional.of(session));
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(arthasClient.executeSystemCommand(eq(serverInfo), eq("arthas-session-1"), eq("reset")))
+                .thenReturn(null);
+        when(arthasClient.closeSession(serverInfo, "arthas-session-1")).thenReturn(true);
+        when(sessionRepository.save(any(ArthasSession.class))).thenReturn(session);
+
+        boolean result = sessionService.closeSession(1L);
+
+        assertThat(result).isTrue();
+        verify(arthasClient).executeSystemCommand(eq(serverInfo), eq("arthas-session-1"), eq("reset"));
+        verify(arthasClient).closeSession(serverInfo, "arthas-session-1");
+        verify(sessionRepository).save(session);
+        assertThat(session.getStatus()).isEqualTo("CLOSED");
+        assertThat(session.getClosedAt()).isNotNull();
+    }
+
+    @Test
+    void closeSession_sessionNotFound_returnsFalse() {
+        when(sessionRepository.findById(99L)).thenReturn(Optional.empty());
+
+        boolean result = sessionService.closeSession(99L);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void cleanupOrphanSessions_success() {
+        ArthasSession orphanSession = new ArthasSession();
+        orphanSession.setId(1L);
+        orphanSession.setServerId("server1");
+        orphanSession.setArthasSessionId("arthas-session-1");
+        orphanSession.setStatus("ACTIVE");
+        orphanSession.setLastActiveAt(LocalDateTime.now().minusMinutes(15));
+
+        when(sessionRepository.findByLastActiveAtBeforeAndStatus(any(LocalDateTime.class), eq("ACTIVE")))
+                .thenReturn(List.of(orphanSession));
+        when(sessionRepository.findById(1L)).thenReturn(Optional.of(orphanSession));
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.empty());
+        when(sessionRepository.save(any(ArthasSession.class))).thenReturn(orphanSession);
+
+        sessionService.cleanupOrphanSessions();
+
+        verify(sessionRepository).save(orphanSession);
+        assertThat(orphanSession.getStatus()).isEqualTo("CLOSED");
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for ArthasSessionService and ArthasSessionController, closing issue #31.\n\n## Summary\n- Added 13 tests for ArthasSessionService (session creation, results pulling, interrupting, closing, cleanup)\n- Added 17 tests for ArthasSessionController (all API endpoints, role-based access control)\n- All 160 tests pass successfully\n\n## Related Issue\nCloses #31