### PR TITLE
fix(audit): skip HttpServletRequest/Response in serialization to prevent getWriter() conflict (#71)

### DIFF
--- a/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
+++ b/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
@@ -8,6 +8,7 @@ import com.zhenduanqi.dto.ExecuteResponse;
 import com.zhenduanqi.entity.SysAuditLog;
 import com.zhenduanqi.repository.AuditLogRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -107,6 +108,8 @@ public class AuditLogAspect {
                 } else if (auditEntry.getTarget() == null) {
                     auditEntry.setTarget(str);
                 }
+            } else if (arg instanceof HttpServletRequest || arg instanceof HttpServletResponse) {
+                continue;
             } else {
                 try {
                     String json = objectMapper.writeValueAsString(arg);
@@ -151,6 +154,9 @@ public class AuditLogAspect {
                     result.append("null");
                 } else if (args[i] instanceof String str) {
                     result.append("\"").append(str).append("\"");
+                } else if (args[i] instanceof HttpServletRequest 
+                        || args[i] instanceof HttpServletResponse) {
+                    result.append("{}");
                 } else {
                     String json = objectMapper.writeValueAsString(args[i]);
                     json = maskJsonFields(json, fieldsToMask);

--- a/src/test/java/com/zhenduanqi/aspect/AuditLogAspectTest.java
+++ b/src/test/java/com/zhenduanqi/aspect/AuditLogAspectTest.java
@@ -304,4 +304,34 @@ class AuditLogAspectTest {
 
         assertThat(result).isEqualTo("success");
     }
+
+    @com.zhenduanqi.annotation.AuditLog(action = "LOGIN")
+    public ResponseEntity<?> loginMethodWithServletResponse(
+            LoginRequest req, jakarta.servlet.http.HttpServletRequest servletRequest,
+            jakarta.servlet.http.HttpServletResponse servletResponse) {
+        return ResponseEntity.ok().build();
+    }
+
+    @Test
+    void loginMethodWithServletResponse_shouldNotCallGetWriter() throws Throwable {
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getMethod()).thenReturn(
+                AuditLogAspectTest.class.getDeclaredMethod("loginMethodWithServletResponse",
+                        LoginRequest.class,
+                        jakarta.servlet.http.HttpServletRequest.class,
+                        jakarta.servlet.http.HttpServletResponse.class));
+        LoginRequest req = new LoginRequest();
+        req.setUsername("admin");
+        req.setPassword("secret123");
+        when(joinPoint.getArgs()).thenReturn(new Object[]{req, request, new MockHttpServletResponse()});
+        when(joinPoint.proceed()).thenReturn(ResponseEntity.ok().build());
+
+        aspect.logAround(joinPoint);
+
+        ArgumentCaptor<SysAuditLog> captor = ArgumentCaptor.forClass(SysAuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        SysAuditLog log = captor.getValue();
+        assertThat(log.getAction()).isEqualTo("LOGIN");
+        assertThat(log.getUsername()).isEqualTo("zhangsan");
+    }
 }


### PR DESCRIPTION
## What does this PR do?

修复登录时 `IllegalStateException: getWriter() has already been called for this response` 错误。

## Root Cause

`AuditLogAspect.serializeWithMasking()` 尝试序列化 `HttpServletResponse` 参数时，Jackson 访问了 `response.writer` 属性，触发了 `getWriter()` 调用，导致后续 Spring 用 `getOutputStream()` 写响应时冲突。

## Changes

1. **`serializeWithMasking()`** 跳过 `HttpServletRequest` 和 `HttpServletResponse` 参数
2. **`extractCommandAndTarget()`** 同样跳过这些参数
3. **新增测试案例** `loginMethodWithServletResponse_shouldNotCallGetWriter`

## Verification

### 问题复现
```bash
mvn spring-boot:run -Dspring-boot.run.arguments="--spring.profiles.active=render --server.port=10001"
curl -X POST http://localhost:10001/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"Abcd1234"}'
# 预期：HTTP 500
```

### 修复后验证
```bash
curl -X POST http://localhost:10001/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"Abcd1234"}'
# 预期：HTTP 200，返回 {"username":"admin","role":"ADMIN"}
```

### 单元测试
```bash
mvn test -Dtest=AuditLogAspectTest
# Tests run: 12, Failures: 0, Errors: 0
```

Closes #71