### PR TITLE
[P2] L2 会话级超时：10分钟自动关闭 (#33)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -541,9 +541,9 @@ CREATE TABLE scene_step (
 | 层 | 机制 | 说明 |
 |----|------|------|
 | L1 命令级超时 | 步骤定义的 `max_exec_time` 字段，默认 30s | 到时后自动 `interrupt_job` |
-| L2 会话级超时 | 每个 Arthas 会话最大存活时间，默认 10 分钟 | 到时后自动 `close_session` + `reset` |
+| L2 会话级超时 | 每个 Arthas 会话最大存活时间，默认 10 分钟 | 到时后自动 `close_session` + `reset`，通过 `cleanupStaleSessions` 定时任务（每 1 分钟）检查 `created_at` |
 | L3 增强类自动重置 | 每个步骤执行结束后立即执行 `reset` 命令 | 清除 watch/trace 的字节码增强，安全优先级最高 |
-| L4 孤儿会话清理 | 后端定时任务（每 5 分钟）扫描超时会话，主动关闭 | 防止任何异常导致的会话泄漏 |
+| L4 孤儿会话清理 | 后端定时任务（每 5 分钟）扫描超时会话 | 检查 `last_active_at`，清理无响应的孤儿会话 |
 
 **会话生命周期：**
 ```
@@ -1005,7 +1005,8 @@ zhenduanqi/
 - ArthasHttpClient 支持 async_exec + pull_results + interrupt_job
 - Arthas 会话管理（创建/轮询/中断/关闭）
 - arthas_session 表 + 持久化
-- L1-L4 安全机制（命令超时、会话超时、自动 reset、孤儿清理定时任务）
+- **L2 会话级超时**：基于 `created_at` 的 10 分钟超时清理（`cleanupStaleSessions` 定时任务，每 1 分钟执行）
+- L4 孤儿清理定时任务（基于 `last_active_at` 的超时清理）
 - 活跃会话管理页（ADMIN）
 - 刷新恢复（重连会话 + 恢复步骤状态）
 - 场景6-8 完整异步模式支持

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.14.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
+++ b/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
@@ -24,4 +24,6 @@ public interface ArthasSessionRepository extends JpaRepository<ArthasSession, Lo
     Optional<ArthasSession> findByIdAndStatus(Long id, String status);
 
     List<ArthasSession> findByLastActiveAtBeforeAndStatus(LocalDateTime before, String status);
+
+    List<ArthasSession> findByCreatedAtBeforeAndStatus(LocalDateTime before, String status);
 }

--- a/src/main/java/com/zhenduanqi/service/ArthasSessionService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasSessionService.java
@@ -215,4 +215,23 @@ public class ArthasSessionService {
         }
         log.info("清理孤儿会话完成: count={}", orphanSessions.size());
     }
+
+    @Scheduled(fixedRate = 1 * 60 * 1000)
+    public void cleanupStaleSessions() {
+        LocalDateTime tenMinutesAgo = LocalDateTime.now().minusMinutes(10);
+        List<ArthasSession> staleSessions = sessionRepository.findByCreatedAtBeforeAndStatus(tenMinutesAgo, "ACTIVE");
+        for (ArthasSession session : staleSessions) {
+            try {
+                log.warn("会话级超时，开始清理: sessionId={}, createdAt={}", session.getId(), session.getCreatedAt());
+                interruptJob(session.getId());
+                closeSession(session.getId());
+                log.info("会话级超时清理完成: sessionId={}", session.getId());
+            } catch (Exception e) {
+                log.error("会话级超时清理失败: sessionId={}", session.getId(), e);
+            }
+        }
+        if (!staleSessions.isEmpty()) {
+            log.info("会话级超时清理完成: count={}", staleSessions.size());
+        }
+    }
 }

--- a/src/test/java/com/zhenduanqi/service/ArthasSessionServiceTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasSessionServiceTest.java
@@ -302,4 +302,66 @@ class ArthasSessionServiceTest {
         verify(sessionRepository).save(orphanSession);
         assertThat(orphanSession.getStatus()).isEqualTo("CLOSED");
     }
+
+    @Test
+    void cleanupStaleSessions_closesSessionsOlderThan10Minutes() {
+        ArthasSession staleSession = new ArthasSession();
+        staleSession.setId(1L);
+        staleSession.setServerId("server1");
+        staleSession.setArthasSessionId("arthas-session-1");
+        staleSession.setStatus("ACTIVE");
+        staleSession.setCreatedAt(LocalDateTime.now().minusMinutes(15));
+        staleSession.setLastActiveAt(LocalDateTime.now().minusMinutes(5));
+
+        when(sessionRepository.findByCreatedAtBeforeAndStatus(any(LocalDateTime.class), eq("ACTIVE")))
+                .thenReturn(List.of(staleSession));
+        when(sessionRepository.findById(1L)).thenReturn(Optional.of(staleSession));
+        ServerInfo serverInfo = createTestServerInfo();
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(sessionRepository.save(any(ArthasSession.class))).thenReturn(staleSession);
+
+        sessionService.cleanupStaleSessions();
+
+        verify(sessionRepository).save(staleSession);
+        assertThat(staleSession.getStatus()).isEqualTo("CLOSED");
+    }
+
+    @Test
+    void cleanupStaleSessions_doesNotCloseRecentSessions() {
+        ArthasSession recentSession = new ArthasSession();
+        recentSession.setId(2L);
+        recentSession.setServerId("server1");
+        recentSession.setStatus("ACTIVE");
+        recentSession.setCreatedAt(LocalDateTime.now().minusMinutes(5));
+
+        when(sessionRepository.findByCreatedAtBeforeAndStatus(any(LocalDateTime.class), eq("ACTIVE")))
+                .thenReturn(List.of());
+
+        sessionService.cleanupStaleSessions();
+
+        verify(sessionRepository, never()).save(any(ArthasSession.class));
+    }
+
+    @Test
+    void cleanupStaleSessions_activeSessionNotClosed() {
+        ArthasSession activeSession = new ArthasSession();
+        activeSession.setId(3L);
+        activeSession.setServerId("server1");
+        activeSession.setArthasSessionId("arthas-session-3");
+        activeSession.setStatus("ACTIVE");
+        activeSession.setCreatedAt(LocalDateTime.now().minusMinutes(15));
+        activeSession.setLastActiveAt(LocalDateTime.now().minusSeconds(30));
+
+        when(sessionRepository.findByCreatedAtBeforeAndStatus(any(LocalDateTime.class), eq("ACTIVE")))
+                .thenReturn(List.of(activeSession));
+        when(sessionRepository.findById(3L)).thenReturn(Optional.of(activeSession));
+        ServerInfo serverInfo = createTestServerInfo();
+        when(serverService.findServerInfoById("server1")).thenReturn(Optional.of(serverInfo));
+        when(sessionRepository.save(any(ArthasSession.class))).thenReturn(activeSession);
+
+        sessionService.cleanupStaleSessions();
+
+        verify(sessionRepository).save(activeSession);
+        assertThat(activeSession.getStatus()).isEqualTo("CLOSED");
+    }
 }


### PR DESCRIPTION
## 实现内容

### Issue
[L2 会话级超时：10分钟超时自动关闭 #33](https://github.com/humoumou1215/zhenduanqi/issues/33)

### 改动

1. **ArthasSessionRepository**：新增 `findByCreatedAtBeforeAndStatus` 方法

2. **ArthasSessionService**：
   - 新增 `cleanupStaleSessions()` 方法，实现 L2 会话级超时
   - 定时任务每 1 分钟执行
   - 检查 `created_at` 超过 10 分钟的 ACTIVE 会话并关闭

3. **ArthasSessionServiceTest**：新增 3 个测试用例

4. **pom.xml**：升级 Mockito 解决 Java 23 兼容性

5. **PRD.md**：同步更新

Closes #33
