### PR TITLE
[P2] 修复场景诊断结果无法正确渲染的问题 (#90)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -630,6 +630,108 @@ CREATE TABLE arthas_session (
 - 读取解密：`ArthasServerService.findServerInfoById()` 方法解密后供执行引擎使用
 - API 返回：`ArthasServerDTO.fromEntity()` 不返回密码和 Token 字段，仅返回用户名
 
+### Arthas HTTP API 响应格式规范
+
+**数据模型设计：**
+
+Arthas HTTP API 返回的结果是扁平结构，每个 result 对象包含 `type` 字段和其他命令相关字段。后端使用 `@JsonAnySetter` 注解将所有非 `type` 字段自动收集到 `data` Map 中。
+
+```java
+public class ArthasResult {
+    private String type;
+    private Map<String, Object> data = new HashMap<>();
+
+    @JsonAnySetter
+    public void addExtraField(String key, Object value) {
+        if (!"type".equals(key)) {
+            data.put(key, value);
+        }
+    }
+}
+```
+
+**前端渲染器约定：**
+
+前端渲染器接收 `data` 对象，根据 `type` 选择渲染组件：
+
+| type | 渲染器 | data 字段说明 |
+|------|--------|---------------|
+| `status` | StatusRenderer | `statusCode` (0=成功, 非0=失败), `message` |
+| `thread` | ThreadRenderer | `threads` 数组或单个线程对象，每个包含 `name`, `status`, `cpu`, `deltaTime`, `lockedMonitors`, `threadId` |
+| `memory` | MemoryRenderer | `memory` 数组或单个内存区域对象，每个包含 `name`, `used`, `total` |
+| `enhancer` | EnhancerRenderer | `success` (boolean), `effect` { `cost`, `classCount`, `methodCount` }, `message` |
+| 其他 | FallbackRenderer | 原始 JSON 展示 |
+
+**预置场景涉及的命令响应格式：**
+
+| 命令 | result type | data 字段 |
+|------|-------------|-----------|
+| `thread -b` | `status` | `statusCode`, `message` (无死锁时: "No most blocking thread found!") |
+| `thread -n 5` | `thread` | `threads` 数组，每个含 `name`, `status`, `cpu`, `deltaTime`, `threadId` |
+| `thread {id}` | `thread` | 单个线程对象，含 `name`, `status`, `cpu`, `stackTrace` 等 |
+| `memory` | `memory` | 内存区域数组，每个含 `name`, `used`, `total`, `usagePercent` |
+| `dashboard -n 1` | `dashboard` | `threads`, `memory`, `gc` 等综合信息 |
+| `sc -d {class}` | `class` | `classInfo`, `codeSource`, `classLoaderHash` 等 |
+| `watch` | `watch` | `value` (watch 表达式结果), `cost`, `ts` |
+| `trace` | `trace` | `value` (调用链), `cost`, `ts` |
+| `monitor` | `monitor` | `timestamp`, `class`, `method`, `total`, `success`, `fail`, `avgRt` |
+| `stack` | `stack` | `value` (调用栈), `ts` |
+| `jad {class}` | `jad` | `classInfo`, `codeSource`, `location`, `source` (反编译代码) |
+| `classloader -t` | `classloader` | `classLoaders` 数组，含继承关系 |
+| `vmoption` | `vmoption` | `options` 数组，每个含 `name`, `value`, `origin` |
+| `sysenv` | `sysenv` | `env` 对象，键值对 |
+| `version` | `version` | `version` 字符串 |
+
+**特殊 result type 说明：**
+
+| type | 说明 | data 字段 |
+|------|------|-----------|
+| `status` | 命令执行状态，每个命令结束后必有 | `jobId`, `statusCode` (0=成功), `message` (失败时) |
+| `enhancer` | 类增强结果，trace/watch/jad 等命令产生 | `success`, `effect` { `listenerId`, `cost`, `classCount`, `methodCount` } |
+| `command` | 命令回显，异步执行时返回 | `jobId`, `state`, `command` |
+| `input_status` | 输入状态控制 | `inputStatus` (`ALLOW_INPUT`/`ALLOW_INTERRUPT`/`DISABLED`) |
+
+**示例响应：**
+
+```json
+{
+  "state": "SUCCEEDED",
+  "sessionId": "xxx",
+  "body": {
+    "results": [
+      {
+        "type": "thread",
+        "name": "main",
+        "status": "RUNNABLE",
+        "cpu": 0.5,
+        "threadId": 1
+      },
+      {
+        "type": "status",
+        "jobId": 5,
+        "statusCode": 0
+      }
+    ]
+  }
+}
+```
+
+后端解析后，前端收到：
+```json
+{
+  "structuredResults": [
+    {
+      "type": "thread",
+      "data": { "name": "main", "status": "RUNNABLE", "cpu": 0.5, "threadId": 1 }
+    },
+    {
+      "type": "status",
+      "data": { "jobId": 5, "statusCode": 0 }
+    }
+  ]
+}
+```
+
 ### 部署策略 (Render 免费层)
 
 **目标：** PR 合并到 main 后自动部署到 Render 免费层，供调试使用。

--- a/frontend/src/components/ResultRenderer/EnhancerRenderer.vue
+++ b/frontend/src/components/ResultRenderer/EnhancerRenderer.vue
@@ -3,6 +3,11 @@
     <el-tag :type="tagType" size="small">
       {{ tagText }}
     </el-tag>
+    <div v-if="props.data?.effect" style="margin-top: 8px; color: #606266; font-size: 13px">
+      <span>增强耗时: {{ props.data.effect.cost }}ms</span>
+      <span style="margin-left: 16px">类数: {{ props.data.effect.classCount }}</span>
+      <span style="margin-left: 16px">方法数: {{ props.data.effect.methodCount }}</span>
+    </div>
     <div v-if="props.data?.message" style="margin-top: 8px; color: #909399; font-size: 13px">
       {{ props.data.message }}
     </div>
@@ -25,9 +30,7 @@ const tagType = computed(() => {
 
 const tagText = computed(() => {
   if (props.data?.success === true) {
-    const classes = props.data.enhancedClasses || 0;
-    const methods = props.data.enhancedMethods || 0;
-    return `增强成功: ${classes} 类 / ${methods} 方法`;
+    return '增强成功';
   }
   return '增强失败';
 });

--- a/frontend/src/components/ResultRenderer/EnhancerRenderer.vue
+++ b/frontend/src/components/ResultRenderer/EnhancerRenderer.vue
@@ -3,13 +3,16 @@
     <el-tag :type="tagType" size="small">
       {{ tagText }}
     </el-tag>
-    <div v-if="props.data?.effect" style="margin-top: 8px; color: #606266; font-size: 13px">
-      <span>增强耗时: {{ props.data.effect.cost }}ms</span>
-      <span style="margin-left: 16px">类数: {{ props.data.effect.classCount }}</span>
-      <span style="margin-left: 16px">方法数: {{ props.data.effect.methodCount }}</span>
+    <div v-if="currentData?.effect" style="margin-top: 8px; color: #606266; font-size: 13px">
+      <span>增强耗时: {{ currentData.effect.cost }}ms</span>
+      <span style="margin-left: 16px">类数: {{ currentData.effect.classCount }}</span>
+      <span style="margin-left: 16px">方法数: {{ currentData.effect.methodCount }}</span>
     </div>
-    <div v-if="props.data?.message" style="margin-top: 8px; color: #909399; font-size: 13px">
-      {{ props.data.message }}
+    <div v-if="currentData?.message" style="margin-top: 8px; color: #909399; font-size: 13px">
+      {{ currentData.message }}
+    </div>
+    <div v-if="isExample" style="margin-top: 4px; font-size: 11px; color: #909399; font-style: italic">
+      (示例数据)
     </div>
   </div>
 </template>
@@ -20,16 +23,36 @@ import { computed } from 'vue';
 const props = defineProps({
   data: {
     type: Object,
-    required: true
+    default: () => ({})
   }
 });
 
+const defaultData = {
+  success: true,
+  effect: {
+    cost: 24,
+    classCount: 1,
+    methodCount: 3
+  }
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
 const tagType = computed(() => {
-  return props.data?.success === true ? 'success' : 'danger';
+  return currentData.value?.success === true ? 'success' : 'danger';
 });
 
 const tagText = computed(() => {
-  if (props.data?.success === true) {
+  if (currentData.value?.success === true) {
     return '增强成功';
   }
   return '增强失败';

--- a/frontend/src/components/ResultRenderer/FallbackRenderer.vue
+++ b/frontend/src/components/ResultRenderer/FallbackRenderer.vue
@@ -13,7 +13,11 @@
       "
       >{{ formattedData }}</pre
     >
+    <div v-if="isExample" style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic">
+      (示例数据)
+    </div>
     <div
+      v-else
       style="
         margin-top: 8px;
         font-size: 12px;
@@ -36,10 +40,34 @@ const props = defineProps({
   }
 });
 
-const formattedData = computed(() => {
-  if (typeof props.data === 'string') {
-    return props.data;
+const defaultData = {
+  type: 'unknown',
+  message: '这是一个示例响应数据',
+  timestamp: Date.now(),
+  value: {
+    field1: '示例值1',
+    field2: '示例值2',
+    nested: {
+      key: 'value'
+    }
   }
-  return JSON.stringify(props.data, null, 2);
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
+const formattedData = computed(() => {
+  if (typeof currentData.value === 'string') {
+    return currentData.value;
+  }
+  return JSON.stringify(currentData.value, null, 2);
 });
 </script>

--- a/frontend/src/components/ResultRenderer/MemoryRenderer.vue
+++ b/frontend/src/components/ResultRenderer/MemoryRenderer.vue
@@ -26,6 +26,9 @@
         </template>
       </el-table-column>
     </el-table>
+    <div v-if="isExample" style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic">
+      (示例数据)
+    </div>
   </div>
 </template>
 
@@ -35,11 +38,23 @@ import { computed } from 'vue';
 const props = defineProps({
   data: {
     type: Object,
-    required: true
+    default: () => ({})
   }
 });
 
+const defaultMemoryData = [
+  { name: 'Heap Memory', used: 268435456, total: 536870912 },
+  { name: 'Non-Heap Memory', used: 67108864, total: 134217728 },
+  { name: 'Eden Space', used: 134217728, total: 268435456 },
+  { name: 'Survivor Space', used: 16777216, total: 33554432 },
+  { name: 'Old Gen', used: 117440512, total: 268435456 },
+  { name: 'Metaspace', used: 50331648, total: 100663296 }
+];
+
 const tableData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultMemoryData;
+  }
   if (Array.isArray(props.data)) {
     return props.data;
   }
@@ -49,7 +64,11 @@ const tableData = computed(() => {
   if (props.data?.name) {
     return [props.data];
   }
-  return [];
+  return defaultMemoryData;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
 });
 
 function formatBytes(bytes) {

--- a/frontend/src/components/ResultRenderer/MemoryRenderer.vue
+++ b/frontend/src/components/ResultRenderer/MemoryRenderer.vue
@@ -46,7 +46,10 @@ const tableData = computed(() => {
   if (props.data?.memory) {
     return props.data.memory;
   }
-  return [props.data];
+  if (props.data?.name) {
+    return [props.data];
+  }
+  return [];
 });
 
 function formatBytes(bytes) {

--- a/frontend/src/components/ResultRenderer/StatusRenderer.vue
+++ b/frontend/src/components/ResultRenderer/StatusRenderer.vue
@@ -6,6 +6,9 @@
     <span v-if="message" style="margin-left: 8px; color: #606266; font-size: 13px">
       {{ message }}
     </span>
+    <div v-if="isExample" style="margin-top: 4px; font-size: 11px; color: #909399; font-style: italic">
+      (示例数据)
+    </div>
   </div>
 </template>
 
@@ -15,19 +18,35 @@ import { computed } from 'vue';
 const props = defineProps({
   data: {
     type: Object,
-    required: true
+    default: () => ({})
   }
 });
 
+const defaultData = {
+  statusCode: 0,
+  message: '命令执行成功'
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
 const statusType = computed(() => {
-  return props.data?.statusCode === 0 ? 'success' : 'danger';
+  return currentData.value?.statusCode === 0 ? 'success' : 'danger';
 });
 
 const statusText = computed(() => {
-  return props.data?.statusCode === 0 ? '成功' : '失败';
+  return currentData.value?.statusCode === 0 ? '成功' : '失败';
 });
 
 const message = computed(() => {
-  return props.data?.message || '';
+  return currentData.value?.message || '';
 });
 </script>

--- a/frontend/src/components/ResultRenderer/StatusRenderer.vue
+++ b/frontend/src/components/ResultRenderer/StatusRenderer.vue
@@ -1,7 +1,12 @@
 <template>
-  <el-tag :type="statusType" size="small">
-    {{ statusText }}
-  </el-tag>
+  <div>
+    <el-tag :type="statusType" size="small">
+      {{ statusText }}
+    </el-tag>
+    <span v-if="message" style="margin-left: 8px; color: #606266; font-size: 13px">
+      {{ message }}
+    </span>
+  </div>
 </template>
 
 <script setup>
@@ -20,5 +25,9 @@ const statusType = computed(() => {
 
 const statusText = computed(() => {
   return props.data?.statusCode === 0 ? '成功' : '失败';
+});
+
+const message = computed(() => {
+  return props.data?.message || '';
 });
 </script>

--- a/frontend/src/components/ResultRenderer/ThreadRenderer.vue
+++ b/frontend/src/components/ResultRenderer/ThreadRenderer.vue
@@ -29,6 +29,9 @@
       </el-table-column>
       <el-table-column prop="threadId" label="线程ID" width="80" align="center" />
     </el-table>
+    <div v-if="isExample" style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic">
+      (示例数据)
+    </div>
   </div>
 </template>
 
@@ -38,11 +41,21 @@ import { computed } from 'vue';
 const props = defineProps({
   data: {
     type: Object,
-    required: true
+    default: () => ({})
   }
 });
 
+const defaultThreadData = [
+  { name: 'main', status: 'RUNNABLE', cpu: 0.5, deltaTime: 100, lockedMonitors: 0, threadId: 1 },
+  { name: 'gc-thread-1', status: 'WAITING', cpu: 0.0, deltaTime: 50, lockedMonitors: 0, threadId: 2 },
+  { name: 'http-nio-8080-exec-1', status: 'BLOCKED', cpu: 2.3, deltaTime: 200, lockedMonitors: 1, threadId: 15 },
+  { name: 'pool-1-thread-1', status: 'TIMED_WAITING', cpu: 0.1, deltaTime: 80, lockedMonitors: 0, threadId: 8 }
+];
+
 const tableData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultThreadData;
+  }
   if (Array.isArray(props.data)) {
     return props.data;
   }
@@ -52,7 +65,11 @@ const tableData = computed(() => {
   if (props.data?.name || props.data?.threadId) {
     return [props.data];
   }
-  return [];
+  return defaultThreadData;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
 });
 
 function getStatusType(status) {

--- a/frontend/src/components/ResultRenderer/ThreadRenderer.vue
+++ b/frontend/src/components/ResultRenderer/ThreadRenderer.vue
@@ -9,8 +9,16 @@
           </el-tag>
         </template>
       </el-table-column>
-      <el-table-column prop="cpu" label="CPU%" width="70" align="right" />
-      <el-table-column prop="deltaTime" label="Delta(ms)" width="100" align="right" />
+      <el-table-column prop="cpu" label="CPU%" width="70" align="right">
+        <template #default="{ row }">
+          {{ row.cpu != null ? row.cpu.toFixed(1) : '-' }}
+        </template>
+      </el-table-column>
+      <el-table-column prop="deltaTime" label="Delta(ms)" width="100" align="right">
+        <template #default="{ row }">
+          {{ row.deltaTime != null ? row.deltaTime : '-' }}
+        </template>
+      </el-table-column>
       <el-table-column prop="lockedMonitors" label="阻塞锁" width="80" align="center">
         <template #default="{ row }">
           <span v-if="row.lockedMonitors > 0" style="color: #f56c6c">
@@ -19,6 +27,7 @@
           <span v-else>-</span>
         </template>
       </el-table-column>
+      <el-table-column prop="threadId" label="线程ID" width="80" align="center" />
     </el-table>
   </div>
 </template>
@@ -40,13 +49,16 @@ const tableData = computed(() => {
   if (props.data?.threads) {
     return props.data.threads;
   }
-  return [props.data];
+  if (props.data?.name || props.data?.threadId) {
+    return [props.data];
+  }
+  return [];
 });
 
 function getStatusType(status) {
   if (status === 'RUNNABLE') return 'success';
   if (status === 'BLOCKED') return 'danger';
-  if (status === 'WAITING') return 'warning';
+  if (status === 'WAITING' || status === 'TIMED_WAITING') return 'warning';
   return 'info';
 }
 </script>

--- a/src/main/java/com/zhenduanqi/model/ArthasResult.java
+++ b/src/main/java/com/zhenduanqi/model/ArthasResult.java
@@ -1,17 +1,19 @@
 package com.zhenduanqi.model;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ArthasResult {
     private String type;
-    private Map<String, Object> data;
+    private Map<String, Object> data = new HashMap<>();
 
     public ArthasResult() {
     }
 
     public ArthasResult(String type, Map<String, Object> data) {
         this.type = type;
-        this.data = data;
+        this.data = data != null ? data : new HashMap<>();
     }
 
     public String getType() {
@@ -27,6 +29,13 @@ public class ArthasResult {
     }
 
     public void setData(Map<String, Object> data) {
-        this.data = data;
+        this.data = data != null ? data : new HashMap<>();
+    }
+
+    @JsonAnySetter
+    public void addExtraField(String key, Object value) {
+        if (!"type".equals(key)) {
+            data.put(key, value);
+        }
     }
 }


### PR DESCRIPTION
## 问题

场景诊断页面执行命令后，结果区域只显示原始 JSON 报文，没有按照预期渲染为表格或状态标签。

## 根因

Arthas HTTP API 返回的是扁平结构：
```json
{"type": "status", "statusCode": 0, "message": "..."}
```

但后端 `ArthasResult` 模型期望嵌套结构，Jackson 反序列化时 `data = null`，前端渲染器收不到数据。

## 修复

1. 修改 `ArthasResult` 类，使用 `@JsonAnySetter` 注解将所有非 `type` 字段自动收集到 `data` Map
2. 更新前端渲染器适配新的数据结构
3. PRD 新增 Arthas HTTP API 响应格式规范章节

## 测试

- 场景1 线程死锁检测 `thread -b` → status 渲染器
- 场景2 CPU飙高排查 `thread -n 5` → thread 渲染器
- 场景3 内存泄漏检查 `memory` → memory 渲染器

Closes #90