### PR TITLE
[P0] 修复 Render 部署失败：ByteBuddy ClassNotFoundException (#92)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>1.14.17</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>

--- a/src/test/java/com/zhenduanqi/ApplicationContextLoadTest.java
+++ b/src/test/java/com/zhenduanqi/ApplicationContextLoadTest.java
@@ -1,0 +1,28 @@
+package com.zhenduanqi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ApplicationContextLoadTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void contextLoads() {
+        assertNotNull(applicationContext, "Application context should load successfully");
+    }
+
+    @Test
+    void entityManagerFactoryBeanExists() {
+        Object emf = applicationContext.getBean("entityManagerFactory");
+        assertNotNull(emf, "entityManagerFactory bean should be created, which requires ByteBuddy at runtime");
+    }
+}


### PR DESCRIPTION
## What

修复 Render 部署时 ByteBuddy ClassNotFoundException 错误。

## Why

Hibernate 依赖 ByteBuddy 进行字节码增强，但 pom.xml 中 byte-buddy 的 scope 被设置为 `test`，导致生产环境打包时缺少该依赖。

## How

1. 移除 byte-buddy 依赖的 `<scope>test</scope>` 配置
2. 添加 ApplicationContextLoadTest 测试验证应用上下文能正常加载

## Verification

- ✅ 本地 `mvn clean package` 成功
- ✅ 打包后的 jar 包含 `BOOT-INF/lib/byte-buddy-1.14.17.jar`
- ✅ 所有测试通过

Closes #92