### PR TITLE
[P1] 新增默认测试服务器 (#88)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -621,6 +621,20 @@ CREATE TABLE arthas_session (
 - `ArthasServerService.findServerInfoById()` 方法统一处理认证信息的解密和组装
 - 前端服务器管理界面区分显示 Basic Auth 字段（用户名、密码）和旧版 Token 字段（标记为已废弃）
 
+**默认测试服务器：**
+系统启动后自动存在一台默认测试服务器，方便用户快速体验系统功能：
+- ID: `server-test`
+- 名称: 测试服务器
+- 主机: `47.99.63.148`
+- HTTP Port: `8563`
+- 用户名: `arthas`
+- 密码: `pswd123`
+
+**前端表单默认值：**
+新增服务器时，前端表单自动填充以下默认值：
+- HTTP Port: `8563`（Arthas 默认 HTTP 端口）
+- Username: `arthas`（Arthas 默认用户名）
+
 **加密方案（适用于密码和 Token）：**
 - 算法：AES/GCM/NoPadding（认证加密，防篡改）
 - IV：每次加密随机生成 12 字节 IV，前置于密文

--- a/frontend/src/views/ServerList.vue
+++ b/frontend/src/views/ServerList.vue
@@ -101,7 +101,7 @@ const defaultForm = () => ({
   name: '',
   host: '',
   httpPort: 8563,
-  username: '',
+  username: 'arthas',
   password: '',
   token: '',
 });

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,6 @@
 INSERT INTO arthas_server (id, name, host, http_port, token, username, password, created_at, updated_at) VALUES ('server-1', '生产环境-应用A', '192.168.1.100', 8563, 'your-arthas-token-here', 'arthas', 'pswd123', NOW(), NOW());
 INSERT INTO arthas_server (id, name, host, http_port, token, username, password, created_at, updated_at) VALUES ('server-2', '测试环境-应用B', '192.168.1.101', 8563, 'your-arthas-token-here', 'arthas', 'pswd123', NOW(), NOW());
+INSERT INTO arthas_server (id, name, host, http_port, token, username, password, created_at, updated_at) VALUES ('server-test', '测试服务器', '47.99.63.148', 8563, null, 'arthas', 'pswd123', NOW(), NOW());
 
 -- 默认角色
 INSERT INTO sys_role (role_code, role_name, description) VALUES ('ADMIN', '管理员', '系统管理员，拥有所有权限');


### PR DESCRIPTION
## What

新增一台默认测试服务器，方便用户快速体验系统功能。同时调整新增服务器时的默认参数。

## Changes

### 1. 添加默认测试服务器

在 `data.sql` 中添加默认服务器记录：

| 属性 | 值 |
|------|-----|
| ID | server-test |
| 名称 | 测试服务器 |
| IP | 47.99.63.148 |
| HTTP Port | 8563 |
| Username | arthas |
| Password | pswd123 |

### 2. 调整新增服务器默认参数

修改前端新增服务器表单的默认值：

| 字段 | 调整为 |
|------|--------|
| HTTP Port | 8563 |
| Username | arthas |

### 3. 更新 PRD

在 PRD.md 的服务器管理章节添加默认测试服务器和前端表单默认值的说明。

## Acceptance Criteria

- [x] 系统启动后自动存在一台测试服务器
- [x] 用户可以直接使用该服务器进行诊断测试
- [x] 新增服务器时 HTTP Port 默认为 8563
- [x] 新增服务器时 Username 默认为 arthas

Closes #88