### PR TITLE
[P1] fix: 线程命令结果渲染问题修复

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -671,7 +671,7 @@ public class ArthasResult {
 | type | 渲染器 | data 字段说明 |
 |------|--------|---------------|
 | `status` | StatusRenderer | `statusCode` (0=成功, 非0=失败), `message` |
-| `thread` | ThreadRenderer | `threads` 数组或单个线程对象，每个包含 `name`, `status`, `cpu`, `deltaTime`, `lockedMonitors`, `threadId` |
+| `thread` | ThreadRenderer | `busyThreads` 数组（`thread -n`）或 `threads` 数组，每个线程含 `name`, `state`(状态), `cpu`, `deltaTime`, `id`(线程ID), `lockedMonitors` |
 | `memory` | MemoryRenderer | `memory` 数组或单个内存区域对象，每个包含 `name`, `used`, `total` |
 | `enhancer` | EnhancerRenderer | `success` (boolean), `effect` { `cost`, `classCount`, `methodCount` }, `message` |
 | 其他 | FallbackRenderer | 原始 JSON 展示 |
@@ -681,8 +681,8 @@ public class ArthasResult {
 | 命令 | result type | data 字段 |
 |------|-------------|-----------|
 | `thread -b` | `status` | `statusCode`, `message` (无死锁时: "No most blocking thread found!") |
-| `thread -n 5` | `thread` | `threads` 数组，每个含 `name`, `status`, `cpu`, `deltaTime`, `threadId` |
-| `thread {id}` | `thread` | 单个线程对象，含 `name`, `status`, `cpu`, `stackTrace` 等 |
+| `thread -n 5` | `thread` | `busyThreads` 数组，每个含 `name`, `state`, `cpu`, `deltaTime`, `id` |
+| `thread {id}` | `thread` | 单个线程对象，含 `name`, `state`, `cpu`, `stackTrace` 等 |
 | `memory` | `memory` | 内存区域数组，每个含 `name`, `used`, `total`, `usagePercent` |
 | `dashboard -n 1` | `dashboard` | `threads`, `memory`, `gc` 等综合信息 |
 | `sc -d {class}` | `class` | `classInfo`, `codeSource`, `classLoaderHash` 等 |

--- a/frontend/src/components/ResultRenderer/ThreadRenderer.vue
+++ b/frontend/src/components/ResultRenderer/ThreadRenderer.vue
@@ -57,16 +57,30 @@ const tableData = computed(() => {
     return defaultThreadData;
   }
   if (Array.isArray(props.data)) {
-    return props.data;
+    return props.data.map(normalizeThread);
+  }
+  if (props.data?.busyThreads) {
+    return props.data.busyThreads.map(normalizeThread);
   }
   if (props.data?.threads) {
-    return props.data.threads;
+    return props.data.threads.map(normalizeThread);
   }
-  if (props.data?.name || props.data?.threadId) {
-    return [props.data];
+  if (props.data?.name || props.data?.threadId || props.data?.id) {
+    return [normalizeThread(props.data)];
   }
   return defaultThreadData;
 });
+
+function normalizeThread(thread) {
+  return {
+    name: thread.name,
+    status: thread.state || thread.status,
+    cpu: thread.cpu,
+    deltaTime: thread.deltaTime,
+    lockedMonitors: thread.lockedMonitors?.length || thread.lockedMonitors || 0,
+    threadId: thread.id || thread.threadId
+  };
+}
 
 const isExample = computed(() => {
   return !props.data || Object.keys(props.data).length === 0;

--- a/src/main/java/com/zhenduanqi/model/ArthasApiResponse.java
+++ b/src/main/java/com/zhenduanqi/model/ArthasApiResponse.java
@@ -1,7 +1,9 @@
 package com.zhenduanqi.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ArthasApiResponse {
     private String state;
     private String sessionId;
@@ -52,6 +54,7 @@ public class ArthasApiResponse {
         this.rawResponse = rawResponse;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Body {
         private List<ArthasResult> results;
         private Integer jobId;

--- a/src/main/java/com/zhenduanqi/service/ArthasServerService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasServerService.java
@@ -58,13 +58,23 @@ public class ArthasServerService {
         info.setHttpPort(entity.getHttpPort());
         
         if (entity.getToken() != null) {
-            info.setToken(encryptionUtil.decrypt(entity.getToken()));
+            try {
+                info.setToken(encryptionUtil.decrypt(entity.getToken()));
+            } catch (Exception e) {
+                log.warn("Token decryption failed, using raw value for server {}", entity.getId());
+                info.setToken(entity.getToken());
+            }
         }
         
         info.setUsername(entity.getUsername());
         
         if (entity.getPassword() != null) {
-            info.setPassword(encryptionUtil.decrypt(entity.getPassword()));
+            try {
+                info.setPassword(encryptionUtil.decrypt(entity.getPassword()));
+            } catch (Exception e) {
+                log.warn("Password decryption failed, using raw value for server {}", entity.getId());
+                info.setPassword(entity.getPassword());
+            }
         }
         
         return info;


### PR DESCRIPTION
## 关联 Issue

Closes #95

## 问题描述

执行  等线程相关命令时，前端无法正确渲染线程表格，只能看到原始 JSON 响应。

## 根本原因

1. **Arthas 响应字段名与前端期望不一致**：
   - Arthas 返回  数组，前端期望 
   - 线程状态字段是 ，前端期望 
   - 线程 ID 字段是 uid=501(huyongsheng) gid=20(staff) groups=20(staff),101(access_bpf),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),701(com.apple.sharepoint.group.1),33(_appstore),98(_lpadmin),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae)，前端期望 

2. **后端 Jackson 解析失败**：
   -  缺少  注解

3. **密码解密问题**：
   - 数据库中存储的明文密码解密失败

## 修复内容

| 文件 | 修复内容 |
|------|----------|
|  | 添加  函数，支持 、、uid=501(huyongsheng) gid=20(staff) groups=20(staff),101(access_bpf),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),701(com.apple.sharepoint.group.1),33(_appstore),98(_lpadmin),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae) 字段映射 |
|  | 添加  注解 |
|  | 解密失败时回退使用原始值 |
|  | 更新 Arthas HTTP API 响应格式规范 |

## 验证结果

