### PR TITLE
[P0] US37 验收 — 客户端 IP 获取 (#103)

### DIFF
--- a/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
+++ b/src/main/java/com/zhenduanqi/aspect/AuditLogAspect.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.zhenduanqi.annotation.AuditLog;
+import com.zhenduanqi.config.ClientIpUtil;
 import com.zhenduanqi.dto.ExecuteResponse;
 import com.zhenduanqi.entity.SysAuditLog;
 import com.zhenduanqi.repository.AuditLogRepository;
@@ -55,7 +56,7 @@ public class AuditLogAspect {
         if (attrs != null) {
             HttpServletRequest req = attrs.getRequest();
             auditEntry.setUsername((String) req.getAttribute("username"));
-            auditEntry.setUserIp(req.getRemoteAddr());
+            auditEntry.setUserIp(ClientIpUtil.extractClientIp(req));
 
             Object[] args = joinPoint.getArgs();
             if (args != null && args.length > 0) {

--- a/src/main/java/com/zhenduanqi/config/ClientIpUtil.java
+++ b/src/main/java/com/zhenduanqi/config/ClientIpUtil.java
@@ -1,0 +1,20 @@
+package com.zhenduanqi.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ClientIpUtil {
+
+    private ClientIpUtil() {}
+
+    public static String extractClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isEmpty()) {
+            return xff.split(",")[0].trim();
+        }
+        String xri = request.getHeader("X-Real-IP");
+        if (xri != null && !xri.isEmpty()) {
+            return xri;
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/zhenduanqi/config/MdcFilter.java
+++ b/src/main/java/com/zhenduanqi/config/MdcFilter.java
@@ -23,7 +23,7 @@ public class MdcFilter implements Filter {
         try {
             MDC.put("requestId", UUID.randomUUID().toString());
             MDC.put("username", extractUsername(req));
-            MDC.put("clientIp", extractClientIp(req));
+            MDC.put("clientIp", ClientIpUtil.extractClientIp(req));
             chain.doFilter(request, response);
         } finally {
             MDC.clear();
@@ -52,17 +52,5 @@ public class MdcFilter implements Filter {
             }
         }
         return null;
-    }
-
-    private String extractClientIp(HttpServletRequest request) {
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff != null && !xff.isEmpty()) {
-            return xff.split(",")[0].trim();
-        }
-        String xri = request.getHeader("X-Real-IP");
-        if (xri != null && !xri.isEmpty()) {
-            return xri;
-        }
-        return request.getRemoteAddr();
     }
 }

--- a/src/test/java/com/zhenduanqi/config/ClientIpUtilTest.java
+++ b/src/test/java/com/zhenduanqi/config/ClientIpUtilTest.java
@@ -1,0 +1,95 @@
+package com.zhenduanqi.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientIpUtilTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    void extractClientIp_returnsXForwardedForFirstIp() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.50, 70.41.3.18, 10.0.0.1");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.50");
+    }
+
+    @Test
+    void extractClientIp_returnsXRealIpWhenNoXForwardedFor() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("203.0.113.99");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.99");
+    }
+
+    @Test
+    void extractClientIp_returnsRemoteAddrWhenNoHeaders() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn(null);
+        when(request.getRemoteAddr()).thenReturn("10.0.1.100");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("10.0.1.100");
+    }
+
+    @Test
+    void extractClientIp_xForwardedForTakesPriorityOverXRealIp() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.50");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.50");
+    }
+
+    @Test
+    void extractClientIp_handlesEmptyXForwardedFor() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn("");
+        when(request.getHeader("X-Real-IP")).thenReturn("203.0.113.99");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.99");
+    }
+
+    @Test
+    void extractClientIp_handlesEmptyXRealIp() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("");
+        when(request.getRemoteAddr()).thenReturn("10.0.1.100");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("10.0.1.100");
+    }
+
+    @Test
+    void extractClientIp_trimsWhitespaceFromXForwardedFor() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn("  203.0.113.50  , 70.41.3.18");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.50");
+    }
+
+    @Test
+    void extractClientIp_singleIpInXForwardedFor() {
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.50");
+
+        String clientIp = ClientIpUtil.extractClientIp(request);
+
+        assertThat(clientIp).isEqualTo("203.0.113.50");
+    }
+}


### PR DESCRIPTION
## 概述
实现反向代理场景下客户端真实 IP 的获取功能。

## 改动
- 新增  工具类，统一 IP 提取逻辑
- 更新  使用 
- 更新  使用 ，确保审计日志  正确记录
- 新增  单元测试

## 验收测试
- ✅ X-Forwarded-For 存在时，取第一个 IP（最原始客户端）
- ✅ X-Real-IP 存在时（无 XFF），使用该值
- ✅ X-Forwarded-For 优先于 X-Real-IP
- ✅ 无代理头时，回退到 remoteAddr
- ✅ MDC 日志 clientIp 正确设置
- ✅ 审计日志 userIp 正确记录

## API 测试结果
```json
// 登录请求带 X-Forwarded-For: 203.0.113.50
// 审计日志记录: userIp = "203.0.113.50"

// 登录请求带 X-Real-IP: 198.51.100.99
// 审计日志记录: userIp = "198.51.100.99"

// 无代理头时
// 审计日志记录: userIp = "0:0:0:0:0:0:0:1" (本地回环)
```

Closes #103