### PR TITLE
[P3] 环境差异化日志级别 (#123)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
             <version>0.12.5</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application-render.yml
+++ b/src/main/resources/application-render.yml
@@ -35,5 +35,5 @@ arthas:
 
 logging:
   level:
-    root: WARN
-    com.zhenduanqi: INFO
+    root: ${LOGGING_LEVEL_ROOT:WARN}
+    com.zhenduanqi: ${LOGGING_LEVEL_COM_ZHENDUANQI:INFO}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,17 @@ arthas:
 
 logging:
   level:
-    root: INFO
-    com.zhenduanqi: DEBUG
+    root: ${LOGGING_LEVEL_ROOT:INFO}
+    com.zhenduanqi: ${LOGGING_LEVEL_COM_ZHENDUANQI:DEBUG}
   file:
-    name: ./logs/zhenduanqi.log
+    name: ${LOGGING_FILE_NAME:./logs/zhenduanqi.log}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: loggers,health
+  endpoint:
+    loggers:
+      enabled: true
+      show-details: when_authorized

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,6 +3,9 @@
 
     <conversionRule conversionWord="maskedMsg" converterClass="com.zhenduanqi.config.SensitiveDataConverter"/>
 
+    <springProperty scope="context" name="ROOT_LEVEL" source="logging.level.root" defaultValue="INFO"/>
+    <springProperty scope="context" name="APP_LEVEL" source="logging.level.com.zhenduanqi" defaultValue="DEBUG"/>
+
     <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{requestId},%X{username}] - %maskedMsg%n"/>
     <property name="LOG_FILE" value="./logs/zhenduanqi.log"/>
 
@@ -26,25 +29,25 @@
     </appender>
 
     <springProfile name="default | dev">
-        <root level="INFO">
+        <root level="${ROOT_LEVEL}">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.zhenduanqi" level="DEBUG"/>
+        <logger name="com.zhenduanqi" level="${APP_LEVEL}"/>
     </springProfile>
 
     <springProfile name="prod">
-        <root level="WARN">
+        <root level="${ROOT_LEVEL}">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
         </root>
-        <logger name="com.zhenduanqi" level="INFO"/>
+        <logger name="com.zhenduanqi" level="${APP_LEVEL}"/>
     </springProfile>
 
     <springProfile name="render">
-        <root level="WARN">
+        <root level="${ROOT_LEVEL}">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.zhenduanqi" level="INFO"/>
+        <logger name="com.zhenduanqi" level="${APP_LEVEL}"/>
     </springProfile>
 
 </configuration>


### PR DESCRIPTION
## 功能描述

实现 US34 - 环境差异化日志级别配置。

## 验收标准完成情况

### Happy Path
- [x] dev/default profile 下 root=INFO, com.zhenduanqi=DEBUG
- [x] prod profile 下 root=WARN, com.zhenduanqi=INFO
- [x] 日志级别可通过配置文件调整

### 边界条件
- [x] render profile 使用 prod 级别
- [x] 环境变量可覆盖日志级别（LOGGING_LEVEL_ROOT, LOGGING_LEVEL_COM_ZHENDUANQI）

### 异常场景
- [x] 配置非法日志级别时使用默认值（Spring Boot 默认处理）
- [x] 日志级别动态调整不需要重启（通过 Actuator 端点）

## 技术变更

1. **pom.xml**: 添加 spring-boot-starter-actuator 依赖
2. **application.yml**: 支持环境变量覆盖日志级别
3. **application-render.yml**: 支持环境变量覆盖日志级别
4. **logback-spring.xml**: 使用 springProperty 从配置读取日志级别

## 验证方式

启动应用后访问  可查看当前日志级别。
通过环境变量  和  可动态调整。

Closes #123