### PR TITLE
[P0] US13 验收 — 用户账号管理 (#104)

### DIFF
--- a/src/main/java/com/zhenduanqi/controller/UserController.java
+++ b/src/main/java/com/zhenduanqi/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.zhenduanqi.controller;
 
+import com.zhenduanqi.annotation.AuditLog;
 import com.zhenduanqi.annotation.RequireRole;
 import com.zhenduanqi.dto.*;
 import com.zhenduanqi.service.UserService;
@@ -28,6 +29,7 @@ public class UserController {
 
     @PostMapping
     @RequireRole("ADMIN")
+    @AuditLog(action = "创建用户")
     public ResponseEntity<?> create(@RequestBody CreateUserRequest req) {
         try {
             return ResponseEntity.status(HttpStatus.CREATED).body(userService.create(req));
@@ -38,16 +40,22 @@ public class UserController {
 
     @PutMapping("/{id}")
     @RequireRole("ADMIN")
+    @AuditLog(action = "更新用户")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody UpdateUserRequest req) {
         try {
             return ResponseEntity.ok(userService.update(id, req));
         } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+            String msg = e.getMessage();
+            if ("用户不存在".equals(msg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", msg));
+            }
+            return ResponseEntity.badRequest().body(Map.of("error", msg));
         }
     }
 
     @PutMapping("/{id}/reset-password")
     @RequireRole("ADMIN")
+    @AuditLog(action = "重置密码")
     public ResponseEntity<?> resetPassword(@PathVariable Long id, @RequestBody ResetPasswordRequest req) {
         try {
             userService.resetPassword(id, req.getNewPassword());

--- a/src/main/java/com/zhenduanqi/service/UserService.java
+++ b/src/main/java/com/zhenduanqi/service/UserService.java
@@ -13,12 +13,17 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
 public class UserService {
 
     private static final Logger log = LoggerFactory.getLogger(UserService.class);
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d).+$");
+    private static final int USERNAME_MIN_LENGTH = 2;
+    private static final int USERNAME_MAX_LENGTH = 50;
+    private static final int REAL_NAME_MAX_LENGTH = 100;
 
     private final SysUserRepository userRepository;
     private final SysRoleRepository roleRepository;
@@ -37,11 +42,12 @@ public class UserService {
     }
 
     public UserResponse create(CreateUserRequest req) {
+        validateUsername(req.getUsername());
+        validatePassword(req.getPassword());
+        validateRealName(req.getRealName());
+
         if (userRepository.findByUsername(req.getUsername()).isPresent()) {
             throw new RuntimeException("用户名已存在");
-        }
-        if (req.getPassword() == null || req.getPassword().length() < 8) {
-            throw new RuntimeException("密码至少8位");
         }
 
         SysUser user = new SysUser();
@@ -66,7 +72,10 @@ public class UserService {
     public UserResponse update(Long id, com.zhenduanqi.dto.UpdateUserRequest req) {
         SysUser user = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("用户不存在"));
-        if (req.getRealName() != null) user.setRealName(req.getRealName());
+        if (req.getRealName() != null) {
+            validateRealName(req.getRealName());
+            user.setRealName(req.getRealName());
+        }
         if (req.getStatus() != null) user.setStatus(req.getStatus());
         if (req.getRoleCodes() != null) {
             Set<SysRole> roles = req.getRoleCodes().stream()
@@ -81,14 +90,36 @@ public class UserService {
     }
 
     public void resetPassword(Long id, String newPassword) {
-        if (newPassword == null || newPassword.length() < 8) {
-            throw new RuntimeException("密码至少8位");
-        }
+        validatePassword(newPassword);
         SysUser user = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("用户不存在"));
         user.setPassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);
         log.info("密码重置: id={}, username={}", id, user.getUsername());
+    }
+
+    private void validateUsername(String username) {
+        if (username == null || username.trim().isEmpty()) {
+            throw new RuntimeException("用户名不能为空");
+        }
+        if (username.length() < USERNAME_MIN_LENGTH || username.length() > USERNAME_MAX_LENGTH) {
+            throw new RuntimeException("用户名长度需在" + USERNAME_MIN_LENGTH + "-" + USERNAME_MAX_LENGTH + "位之间");
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (password == null || password.length() < 8) {
+            throw new RuntimeException("密码至少8位");
+        }
+        if (!PASSWORD_PATTERN.matcher(password).matches()) {
+            throw new RuntimeException("密码必须包含字母和数字");
+        }
+    }
+
+    private void validateRealName(String realName) {
+        if (realName != null && realName.length() > REAL_NAME_MAX_LENGTH) {
+            throw new RuntimeException("真实姓名不能超过" + REAL_NAME_MAX_LENGTH + "位");
+        }
     }
 
     private UserResponse toResponse(SysUser user) {

--- a/src/test/java/com/zhenduanqi/service/UserServiceTest.java
+++ b/src/test/java/com/zhenduanqi/service/UserServiceTest.java
@@ -84,4 +84,70 @@ class UserServiceTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("密码至少8位");
     }
+
+    @Test
+    void create_withPasswordWithoutLetter_throwsException() {
+        userService = new UserService(userRepository, roleRepository, passwordEncoder);
+
+        CreateUserRequest req = new CreateUserRequest();
+        req.setUsername("zhangsan");
+        req.setPassword("12345678");
+
+        assertThatThrownBy(() -> userService.create(req))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("密码必须包含字母和数字");
+    }
+
+    @Test
+    void create_withPasswordWithoutDigit_throwsException() {
+        userService = new UserService(userRepository, roleRepository, passwordEncoder);
+
+        CreateUserRequest req = new CreateUserRequest();
+        req.setUsername("zhangsan");
+        req.setPassword("abcdefgh");
+
+        assertThatThrownBy(() -> userService.create(req))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("密码必须包含字母和数字");
+    }
+
+    @Test
+    void create_withShortUsername_throwsException() {
+        userService = new UserService(userRepository, roleRepository, passwordEncoder);
+
+        CreateUserRequest req = new CreateUserRequest();
+        req.setUsername("a");
+        req.setPassword("Abcd1234");
+
+        assertThatThrownBy(() -> userService.create(req))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("用户名长度需在2-50位之间");
+    }
+
+    @Test
+    void create_withEmptyUsername_throwsException() {
+        userService = new UserService(userRepository, roleRepository, passwordEncoder);
+
+        CreateUserRequest req = new CreateUserRequest();
+        req.setUsername("");
+        req.setPassword("Abcd1234");
+
+        assertThatThrownBy(() -> userService.create(req))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("用户名不能为空");
+    }
+
+    @Test
+    void create_withLongRealName_throwsException() {
+        userService = new UserService(userRepository, roleRepository, passwordEncoder);
+
+        CreateUserRequest req = new CreateUserRequest();
+        req.setUsername("zhangsan");
+        req.setPassword("Abcd1234");
+        req.setRealName("a".repeat(101));
+
+        assertThatThrownBy(() -> userService.create(req))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("真实姓名不能超过100位");
+    }
 }


### PR DESCRIPTION
Closes #104

## 实现内容

### Happy Path
- [x] 管理员可以查看用户列表
- [x] 管理员可以创建新用户（用户名、密码、真实姓名、角色）
- [x] 管理员可以编辑用户信息
- [x] 管理员可以重置用户密码
- [x] 管理员可以禁用/启用用户账号
- [x] 用户管理操作有审计日志记录

### 边界条件
- [x] 用户名不能重复
- [x] 密码强度校验：至少 8 位，必须包含字母 + 数字
- [x] 用户名长度限制（2-50位）
- [x] 真实姓名长度限制（最大100位）

### 异常场景
- [x] 非管理员用户访问用户管理页面，返回 403（已有 RoleAspect 实现）
- [x] 创建用户时用户名已存在，显示错误提示
- [x] 编辑不存在的用户，返回 404
- [x] 重置密码时密码强度不符合要求，显示错误提示

## 验证方式

使用 Playwright 进行端到端验证，测试结果：
- ✅ 登录管理员账号
- ✅ 查看用户列表
- ✅ 创建用户 - 正常流程
- ✅ 创建用户 - 用户名重复
- ✅ 创建用户 - 密码校验
- ✅ 编辑用户
- ✅ 重置密码 - 弱密码拒绝
- ✅ 重置密码 - 正常流程
- ✅ 禁用用户

## 代码改动

1. **UserController.java**: 添加 @AuditLog 注解，编辑不存在用户返回 404
2. **UserService.java**: 添加密码强度校验、用户名长度校验、真实姓名长度校验
3. **UserServiceTest.java**: 添加新校验逻辑的单元测试