### PR TITLE
[P0] US17 验收 — 普通操作员权限 (#106)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,7 +27,7 @@
         <el-menu-item index="/command-guard" v-if="userStore.role === 'ADMIN'" style="color: white">
           命令守卫
         </el-menu-item>
-        <el-menu-item index="/sessions" v-if="userStore.role === 'ADMIN'" style="color: white">
+        <el-menu-item index="/sessions" v-if="userStore.role === 'ADMIN' || userStore.role === 'OPERATOR'" style="color: white">
           会话管理
         </el-menu-item>
       </el-menu>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -27,7 +27,11 @@
         <el-menu-item index="/command-guard" v-if="userStore.role === 'ADMIN'" style="color: white">
           命令守卫
         </el-menu-item>
-        <el-menu-item index="/sessions" v-if="userStore.role === 'ADMIN' || userStore.role === 'OPERATOR'" style="color: white">
+        <el-menu-item
+          index="/sessions"
+          v-if="userStore.role === 'ADMIN' || userStore.role === 'OPERATOR'"
+          style="color: white"
+        >
           会话管理
         </el-menu-item>
       </el-menu>


### PR DESCRIPTION
Closes #106

## 修改内容

修复普通操作员权限的前端菜单显示问题：

- 会话管理菜单现在对 OPERATOR 角色可见（之前只对 ADMIN 可见）

## 验收标准验证

### Happy Path
- [x] 操作员可以登录系统
- [x] 操作员可以查看服务器列表
- [x] 操作员可以查看服务器详情
- [x] 操作员可以执行自由命令
- [x] 操作员可以使用场景模板
- [x] 操作员可以查看自己的执行历史

### 边界条件
- [x] 操作员看不到服务器管理按钮（新增/编辑/删除）
- [x] 操作员看不到用户管理菜单
- [x] 操作员看不到审计日志菜单
- [x] 操作员看不到命令守卫菜单
- [x] 操作员可以看到会话管理菜单

### 异常场景
- [x] 操作员尝试创建/编辑/删除服务器，返回 403
- [x] 操作员尝试创建/编辑/删除用户，返回 403
- [x] 操作员尝试查看审计日志，返回 403
- [x] 操作员尝试配置命令守卫规则，返回 403
- [x] 操作员直接调用管理 API 时返回 403

## Playwright 验证结果

```
=== Menu visibility test PASSED ===

Testing access to /servers page...
Server list page: Add button and Action column hidden - PASSED

Testing access to /sessions page...
Sessions page accessible - PASSED

Testing API access control...

API access control results:
  GET /api/users -> 403 FORBIDDEN (expected)
  GET /api/audit-logs -> 403 FORBIDDEN (expected)
  GET /api/command-guard/rules -> 403 FORBIDDEN (expected)
  GET /api/servers -> 200 OK (expected)
  GET /api/arthas-sessions -> 200 OK (expected)

=== All Operator Permission Tests PASSED ===
```

## 截图

操作员登录后的菜单：
- 场景列表 ✅
- 执行诊断 ✅
- 会话管理 ✅
- 服务器管理 ❌（隐藏）
- 用户管理 ❌（隐藏）
- 审计日志 ❌（隐藏）
- 命令守卫 ❌（隐藏）