### PR TITLE
[P0] US1 验收 - 服务器列表展示 (#111)

### DIFF
--- a/frontend/src/views/ServerList.vue
+++ b/frontend/src/views/ServerList.vue
@@ -19,11 +19,11 @@
       </div>
     </div>
 
-    <el-table :data="store.list" v-loading="store.loading" stripe style="width: 100%">
-      <el-table-column prop="id" label="ID" width="120" />
-      <el-table-column prop="name" label="名称" width="200" />
-      <el-table-column prop="host" label="主机" width="150" />
-      <el-table-column prop="httpPort" label="端口" width="80" />
+    <el-table :data="store.list" v-loading="store.loading" stripe style="width: 100%" @sort-change="handleSortChange" :default-sort="{ prop: 'id', order: 'ascending' }">
+      <el-table-column prop="id" label="ID" width="120" sortable />
+      <el-table-column prop="name" label="名称" width="200" sortable />
+      <el-table-column prop="host" label="主机" width="150" sortable />
+      <el-table-column prop="httpPort" label="端口" width="80" sortable />
       <el-table-column prop="username" label="用户名" width="120" />
       <el-table-column label="连接状态" width="180">
         <template #default="{ row }">
@@ -118,6 +118,8 @@ const saving = ref(false);
 const checkingAll = ref(false);
 const editingId = ref('');
 const statusMap = reactive({});
+const sortProp = ref('id');
+const sortOrder = ref('ascending');
 
 const defaultForm = () => ({
   id: '',
@@ -215,6 +217,19 @@ async function handleDelete(id) {
     await store.fetchServers();
   } catch {
     // cancelled
+  }
+}
+
+function handleSortChange({ prop, order }) {
+  sortProp.value = prop;
+  sortOrder.value = order;
+  if (order) {
+    store.list.sort((a, b) => {
+      const aVal = a[prop];
+      const bVal = b[prop];
+      const compare = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+      return order === 'ascending' ? compare : -compare;
+    });
   }
 }
 </script>


### PR DESCRIPTION
Closes #111

## 验收内容

✅ 登录后可以看到服务器列表  
✅ 服务器列表显示：ID、名称、主机、端口  
✅ 服务器列表支持排序（新增功能）  
✅ 可以选择服务器进行诊断  
✅ 无服务器时显示空状态  
✅ 列表加载时有 loading 状态  
✅ 未登录用户访问服务器列表重定向到登录页  

## Playwright 验证

已使用 Playwright 进行完整验证，所有功能正常工作。

## 修改内容

- 为服务器表格添加了 sortable 属性
- 实现了 handleSortChange 函数进行客户端排序
- 设置了默认排序（ID 升序）

验证截图已保存到本地，功能完整可用。