### PR TITLE
[P0] US27 验收 — 命令执行链路日志 (#118)

### DIFF
--- a/src/main/java/com/zhenduanqi/client/ArthasHttpClient.java
+++ b/src/main/java/com/zhenduanqi/client/ArthasHttpClient.java
@@ -56,7 +56,7 @@ public class ArthasHttpClient {
             
             HttpRequest request = requestBuilder.build();
 
-            log.info("Executing command on {}: {}", server.getName(), command);
+            log.debug("ArthasClient: 正在发送命令到 Arthas, server={}, command={}", server.getName(), summarizeCommand(command));
             HttpResponse<String> httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
             String body = httpResponse.body();
@@ -79,20 +79,22 @@ public class ArthasHttpClient {
             response.setState("failed");
             response.setError("无法连接到服务器: " + e.getMessage());
             response.setRawResponse("连接错误: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            log.error("Connection failed: {}", e.getMessage());
+            log.error("ArthasClient: 连接失败, server={}, error={}", server.getName(), e.getMessage());
         } catch (java.net.http.HttpConnectTimeoutException e) {
             response.setState("failed");
             response.setError("连接超时: " + e.getMessage());
             response.setRawResponse("连接超时: " + e.getMessage());
+            log.warn("ArthasClient: 连接超时, server={}", server.getName());
         } catch (java.net.http.HttpTimeoutException e) {
             response.setState("failed");
             response.setError("请求超时: " + e.getMessage());
             response.setRawResponse("请求超时: " + e.getMessage());
+            log.warn("ArthasClient: 请求超时, server={}", server.getName());
         } catch (Exception e) {
             response.setState("failed");
             response.setError("请求异常: " + e.getMessage());
             response.setRawResponse("请求异常: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            log.error("Arthas API request failed", e);
+            log.error("ArthasClient: 请求异常, server={}", server.getName(), e);
         }
 
         return response;
@@ -157,6 +159,13 @@ public class ArthasHttpClient {
                 .replace("\n", "\\n")
                 .replace("\r", "\\r")
                 .replace("\t", "\\t");
+    }
+    
+    private String summarizeCommand(String command) {
+        if (command == null) return "";
+        if (command.length() <= 50) return command;
+        String firstWord = command.split("\\s+")[0];
+        return firstWord + "...";
     }
 
     public boolean checkConnection(ServerInfo server) {

--- a/src/main/java/com/zhenduanqi/service/ArthasExecuteService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasExecuteService.java
@@ -47,20 +47,34 @@ public class ArthasExecuteService {
     }
 
     public ExecuteResponse execute(String serverId, String command) {
-        log.info("命令执行开始: serverId={}, command={}", serverId, command.length() > 50 ? command.substring(0, 50) + "..." : command);
+        String commandSummary = summarizeCommand(command);
+        log.info("CommandChain: 接收命令执行请求, serverId={}, command={}", serverId, commandSummary);
         long start = System.currentTimeMillis();
 
         CommandGuardService.GuardResult guardResult = commandGuardService.check(command);
         if (guardResult.isBlocked()) {
+            log.warn("CommandChain: 命令被拦截, serverId={}, command={}, reason={}", 
+                    serverId, commandSummary, guardResult.getReason());
             ExecuteResponse resp = new ExecuteResponse();
             resp.setState("blocked");
             resp.setError(guardResult.getReason());
             return resp;
         }
+        
+        log.info("CommandChain: 校验通过，发送到 Arthas, serverId={}, command={}", serverId, commandSummary);
         ExecuteResponse result = doExecute(serverId, command);
         long duration = System.currentTimeMillis() - start;
-        log.info("命令执行完成: serverId={}, state={}, duration={}ms", serverId, result.getState(), duration);
+        
+        log.info("CommandChain: 收到响应, serverId={}, state={}, duration={}ms, command={}", 
+                serverId, result.getState(), duration, commandSummary);
         return result;
+    }
+    
+    private String summarizeCommand(String command) {
+        if (command == null) return "";
+        if (command.length() <= 50) return command;
+        String firstWord = command.split("\\s+")[0];
+        return firstWord + "...";
     }
 
     public ExecuteResponse executeSystemCommand(String serverId, String command) {

--- a/src/main/java/com/zhenduanqi/service/CommandGuardService.java
+++ b/src/main/java/com/zhenduanqi/service/CommandGuardService.java
@@ -42,23 +42,32 @@ public class CommandGuardService {
         String commandName = trimmedCommand.split("\\s+")[0].toLowerCase();
         
         if (SYSTEM_COMMANDS.contains(commandName)) {
-            log.debug("系统命令豁免: {}", commandName);
+            log.debug("CommandGuard: 系统命令豁免, commandName={}", commandName);
             return new GuardResult(false, null);
         }
         
         for (CompiledRule rule : whitelistRules) {
             if (rule.pattern.matcher(trimmedCommand).find()) {
+                log.debug("CommandGuard: 白名单匹配通过, command={}", summarizeCommand(trimmedCommand));
                 return new GuardResult(false, null);
             }
         }
         for (CompiledRule rule : blacklistRules) {
             if (rule.pattern.matcher(trimmedCommand).find()) {
-                log.warn("高危命令拦截: command=\"{}\", pattern={}, description={}", 
-                        command, rule.pattern.pattern(), rule.description);
+                log.warn("CommandGuard: 高危命令拦截, command=\"{}\", pattern={}, description={}", 
+                        trimmedCommand, rule.pattern.pattern(), rule.description);
                 return new GuardResult(true, "高危命令已被拦截: " + commandName);
             }
         }
+        log.debug("CommandGuard: 校验通过, command={}", summarizeCommand(trimmedCommand));
         return new GuardResult(false, null);
+    }
+    
+    private String summarizeCommand(String command) {
+        if (command == null) return "";
+        if (command.length() <= 50) return command;
+        String firstWord = command.split("\\s+")[0];
+        return firstWord + "...";
     }
 
     public List<CommandGuardRule> getAllRules() {

--- a/src/test/java/com/zhenduanqi/service/ArthasExecuteServiceLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasExecuteServiceLoggingTest.java
@@ -70,7 +70,7 @@ class ArthasExecuteServiceLoggingTest {
 
             List<ILoggingEvent> events = appender.list;
             assertThat(events.stream().anyMatch(e ->
-                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("命令执行开始"))).isTrue();
+                    e.getLevel() == Level.INFO && e.getFormattedMessage().contains("CommandChain: 接收命令执行请求"))).isTrue();
         } finally {
             removeAppender(appender);
         }


### PR DESCRIPTION
## 实现内容

为 Arthas 命令执行添加完整的链路日志追踪，实现验收标准：

### Happy Path 日志
- ✅ 接收请求时记录 INFO 日志（含 serverId、命令摘要）
- ✅ CommandGuard 校验通过时记录 DEBUG 日志
- ✅ 发送到 Arthas 时记录 DEBUG 日志
- ✅ 收到响应时记录 INFO 日志（含结果状态、耗时）

### 边界条件
- ✅ 日志包含 requestId（通过 MDC 自动注入）
- ✅ 日志包含 serverId
- ✅ 日志包含命令摘要（超过50字符只显示命令名）

### 异常场景
- ✅ Arthas 连接失败时记录 ERROR 日志
- ✅ Arthas 响应超时时记录 WARN 日志
- ✅ 命令被拦截时记录 WARN 日志

## 代码变更

| 文件 | 变更 |
|------|------|
|  | 添加完整的命令链路日志 |
|  | 添加校验通过/拦截日志 |
|  | 优化异常日志，添加发送日志 |

## 日志示例



Closes #118