### PR TITLE
[P0] US10 验收 — 诊断历史查看 (#115)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -947,6 +947,7 @@ CREATE TABLE arthas_session (
 | POST | `/api/arthas-sessions/{id}/interrupt` | 中断当前命令 | OPERATOR, ADMIN |
 | POST | `/api/arthas-sessions/{id}/close` | 关闭会话（reset+close） | OPERATOR, ADMIN |
 | GET | `/api/audit-logs` | 审计日志（分页+筛选） | ADMIN |
+| GET | `/api/my-history` | 当前用户的诊断历史（分页+筛选） | 已认证 |
 | GET | `/api/command-guard/rules` | 高危命令规则列表 | ADMIN |
 | POST | `/api/command-guard/rules` | 新增规则 | ADMIN |
 | PUT | `/api/command-guard/rules/{id}` | 更新规则 | ADMIN |
@@ -1181,7 +1182,6 @@ zhenduanqi/
 - **LDAP/OAuth 集成**：企业级 SSO 集成，后续迭代
 - **多语言（i18n）**：当前仅中文，暂无国际化计划
 - **Docker/K8s 部署**：当前仅提供 jar 独立部署，后续可按需提供
-- **诊断历史个人查询**：当前仅 ADMIN 可查全部审计日志，后续可增加个人查询入口
 
 ## Further Notes
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,7 @@
       >
         <el-menu-item index="/scenes" style="color: white">场景列表</el-menu-item>
         <el-menu-item index="/diagnose" style="color: white">执行诊断</el-menu-item>
+        <el-menu-item index="/my-history" style="color: white">我的历史</el-menu-item>
         <el-menu-item index="/servers" v-if="userStore.role === 'ADMIN'" style="color: white">
           服务器管理
         </el-menu-item>

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -88,6 +88,10 @@ export function getAuditLogs(params) {
   return api.get('/audit-logs', { params });
 }
 
+export function getMyHistory(params) {
+  return api.get('/my-history', { params });
+}
+
 export function getGuardRules() {
   return api.get('/command-guard/rules');
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -58,6 +58,12 @@ const routes = [
     component: () => import('../views/SessionManage.vue'),
     meta: { requiresAuth: true },
   },
+  {
+    path: '/my-history',
+    name: 'MyHistory',
+    component: () => import('../views/MyHistory.vue'),
+    meta: { requiresAuth: true },
+  },
 ];
 
 const router = createRouter({

--- a/frontend/src/views/MyHistory.vue
+++ b/frontend/src/views/MyHistory.vue
@@ -1,0 +1,201 @@
+<template>
+  <div>
+    <h3>我的诊断历史</h3>
+
+    <el-card style="margin-bottom: 16px">
+      <el-form :model="filters" inline>
+        <el-form-item label="操作类型">
+          <el-select
+            v-model="filters.action"
+            placeholder="全部"
+            clearable
+            style="width: 160px"
+            @change="search"
+          >
+            <el-option label="执行命令" value="EXECUTE_COMMAND" />
+            <el-option label="登录" value="LOGIN" />
+            <el-option label="登出" value="LOGOUT" />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="目标服务器">
+          <el-select
+            v-model="filters.target"
+            placeholder="全部"
+            clearable
+            filterable
+            style="width: 180px"
+            @change="search"
+          >
+            <el-option
+              v-for="server in servers"
+              :key="server.id"
+              :label="server.name"
+              :value="server.id"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="时间">
+          <el-date-picker
+            v-model="timeRange"
+            type="datetimerange"
+            range-separator="至"
+            start-placeholder="开始"
+            end-placeholder="结束"
+            value-format="YYYY-MM-DDTHH:mm:ss"
+            @change="search"
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" @click="search">查询</el-button>
+          <el-button @click="reset">重置</el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+
+    <el-table
+      :data="logs"
+      v-loading="loading"
+      stripe
+      style="width: 100%"
+      @sort-change="onSortChange"
+      :empty-text="emptyText"
+    >
+      <el-table-column prop="createdAt" label="执行时间" width="170" sortable="custom">
+        <template #default="{ row }">{{ formatTime(row.createdAt) }}</template>
+      </el-table-column>
+      <el-table-column prop="target" label="服务器" width="140" />
+      <el-table-column prop="command" label="命令" min-width="180" show-overflow-tooltip />
+      <el-table-column prop="result" label="结果" width="90">
+        <template #default="{ row }">
+          <el-tag
+            :type="
+              row.result === 'SUCCESS' ? 'success' : row.result === 'BLOCKED' ? 'warning' : 'danger'
+            "
+            size="small"
+          >
+            {{ row.result }}
+          </el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column prop="durationMs" label="耗时(ms)" width="90" sortable="custom" />
+      <el-table-column type="expand" label="详情">
+        <template #default="{ row }">
+          <div style="padding: 12px">
+            <div v-if="row.command">
+              <strong>命令：</strong>
+              <pre style="background: #f5f7fa; padding: 8px; margin: 4px 0">{{ row.command }}</pre>
+            </div>
+            <div v-if="row.resultDetail">
+              <strong>结果详情：</strong>
+              <pre style="background: #f5f7fa; padding: 8px; margin: 4px 0">{{
+                row.resultDetail
+              }}</pre>
+            </div>
+          </div>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <div style="margin-top: 16px; display: flex; justify-content: flex-end">
+      <el-pagination
+        v-model:current-page="page"
+        v-model:page-size="pageSize"
+        :total="total"
+        :page-sizes="[10, 20, 50, 100]"
+        layout="total, sizes, prev, pager, next"
+        @size-change="fetchLogs"
+        @current-change="fetchLogs"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted, computed } from 'vue';
+import { getMyHistory, getServers } from '../api';
+
+const logs = ref([]);
+const servers = ref([]);
+const loading = ref(false);
+const page = ref(1);
+const pageSize = ref(20);
+const total = ref(0);
+const sortField = ref('createdAt');
+const sortOrder = ref('desc');
+const timeRange = ref(null);
+
+const filters = reactive({ action: '', target: '' });
+
+const emptyText = computed(() => {
+  if (loading.value) return '加载中...';
+  if (total.value === 0) {
+    if (filters.action || filters.target || timeRange.value) {
+      return '没有符合筛选条件的记录';
+    }
+    return '暂无诊断历史';
+  }
+  return '暂无数据';
+});
+
+onMounted(() => {
+  fetchServers();
+  fetchLogs();
+});
+
+async function fetchServers() {
+  try {
+    const res = await getServers();
+    servers.value = res.data;
+  } catch (e) {
+    console.error('Failed to fetch servers:', e);
+  }
+}
+
+function formatTime(t) {
+  if (!t) return '';
+  return t.replace('T', ' ').substring(0, 19);
+}
+
+async function fetchLogs() {
+  loading.value = true;
+  try {
+    const params = {
+      page: page.value - 1,
+      size: pageSize.value,
+      sort: sortField.value + ',' + sortOrder.value,
+    };
+    if (filters.action) params.action = filters.action;
+    if (filters.target) params.target = filters.target;
+    if (timeRange.value) {
+      params.startTime = timeRange.value[0];
+      params.endTime = timeRange.value[1];
+    }
+    const res = await getMyHistory(params);
+    logs.value = res.data.content;
+    total.value = res.data.totalElements;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function search() {
+  page.value = 1;
+  fetchLogs();
+}
+
+function reset() {
+  filters.action = '';
+  filters.target = '';
+  timeRange.value = null;
+  page.value = 1;
+  fetchLogs();
+}
+
+function onSortChange(col) {
+  if (col.prop) {
+    sortField.value = col.prop;
+    sortOrder.value = col.order === 'ascending' ? 'asc' : 'desc';
+    fetchLogs();
+  }
+}
+</script>

--- a/src/main/java/com/zhenduanqi/controller/MyHistoryController.java
+++ b/src/main/java/com/zhenduanqi/controller/MyHistoryController.java
@@ -1,0 +1,48 @@
+package com.zhenduanqi.controller;
+
+import com.zhenduanqi.entity.SysAuditLog;
+import com.zhenduanqi.service.AuditLogService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/my-history")
+public class MyHistoryController {
+
+    private final AuditLogService auditLogService;
+
+    public MyHistoryController(AuditLogService auditLogService) {
+        this.auditLogService = auditLogService;
+    }
+
+    @GetMapping
+    public Page<SysAuditLog> getMyHistory(
+            @RequestParam(required = false) String action,
+            @RequestParam(required = false) String target,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startTime,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endTime,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt") String sortField,
+            @RequestParam(defaultValue = "desc") String sortDirection,
+            HttpServletRequest request) {
+
+        String username = (String) request.getAttribute("username");
+        if (username == null) {
+            throw new IllegalStateException("用户未认证");
+        }
+
+        Sort.Direction direction = "asc".equalsIgnoreCase(sortDirection) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        return auditLogService.queryMyHistory(username, action, target, startTime, endTime,
+                PageRequest.of(page, size, Sort.by(direction, sortField)));
+    }
+}

--- a/src/main/java/com/zhenduanqi/service/AuditLogService.java
+++ b/src/main/java/com/zhenduanqi/service/AuditLogService.java
@@ -45,4 +45,27 @@ public class AuditLogService {
         };
         return repository.findAll(spec, pageable);
     }
+
+    public Page<SysAuditLog> queryMyHistory(String username, String action, String target,
+                                            LocalDateTime startTime, LocalDateTime endTime,
+                                            Pageable pageable) {
+        Specification<SysAuditLog> spec = (root, q, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("username"), username));
+            if (action != null && !action.isEmpty()) {
+                predicates.add(cb.equal(root.get("action"), action));
+            }
+            if (target != null && !target.isEmpty()) {
+                predicates.add(cb.like(root.get("target"), "%" + target + "%"));
+            }
+            if (startTime != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), startTime));
+            }
+            if (endTime != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("createdAt"), endTime));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return repository.findAll(spec, pageable);
+    }
 }

--- a/src/test/java/com/zhenduanqi/controller/MyHistoryControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/MyHistoryControllerTest.java
@@ -1,0 +1,118 @@
+package com.zhenduanqi.controller;
+
+import com.zhenduanqi.entity.SysAuditLog;
+import com.zhenduanqi.entity.SysRole;
+import com.zhenduanqi.entity.SysUser;
+import com.zhenduanqi.repository.SysUserRepository;
+import com.zhenduanqi.service.AuditLogService;
+import com.zhenduanqi.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MyHistoryController.class)
+class MyHistoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuditLogService auditLogService;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private SysUserRepository userRepository;
+
+    @Test
+    void getMyHistory_returnsOnlyCurrentUserLogs() throws Exception {
+        SysAuditLog log = new SysAuditLog();
+        log.setId(1L);
+        log.setUsername("zhangsan");
+        log.setAction("EXECUTE_COMMAND");
+        log.setCommand("thread -n 5");
+        log.setTarget("server-1");
+        log.setResult("SUCCESS");
+        log.setDurationMs(100L);
+
+        SysUser normalUser = new SysUser();
+        normalUser.setUsername("zhangsan");
+        SysRole operatorRole = new SysRole();
+        operatorRole.setRoleCode("OPERATOR");
+        normalUser.setRoles(Set.of(operatorRole));
+
+        when(authService.validateToken("valid-jwt")).thenReturn("zhangsan");
+        when(userRepository.findByUsername("zhangsan")).thenReturn(java.util.Optional.of(normalUser));
+        when(auditLogService.queryMyHistory(eq("zhangsan"), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/my-history")
+                        .cookie(new jakarta.servlet.http.Cookie("zhenduanqi_token", "valid-jwt")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].username").value("zhangsan"))
+                .andExpect(jsonPath("$.content[0].command").value("thread -n 5"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void getMyHistory_withFilters_returnsFilteredLogs() throws Exception {
+        SysAuditLog log = new SysAuditLog();
+        log.setId(1L);
+        log.setUsername("zhangsan");
+        log.setAction("EXECUTE_COMMAND");
+        log.setTarget("server-1");
+        log.setResult("SUCCESS");
+
+        SysUser normalUser = new SysUser();
+        normalUser.setUsername("zhangsan");
+        SysRole operatorRole = new SysRole();
+        operatorRole.setRoleCode("OPERATOR");
+        normalUser.setRoles(Set.of(operatorRole));
+
+        when(authService.validateToken("valid-jwt")).thenReturn("zhangsan");
+        when(userRepository.findByUsername("zhangsan")).thenReturn(java.util.Optional.of(normalUser));
+        when(auditLogService.queryMyHistory(eq("zhangsan"), eq("EXECUTE_COMMAND"), eq("server-1"), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(log), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/my-history")
+                        .cookie(new jakarta.servlet.http.Cookie("zhenduanqi_token", "valid-jwt"))
+                        .param("action", "EXECUTE_COMMAND")
+                        .param("target", "server-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].action").value("EXECUTE_COMMAND"))
+                .andExpect(jsonPath("$.content[0].target").value("server-1"));
+    }
+
+    @Test
+    void getMyHistory_emptyResult_returnsEmptyPage() throws Exception {
+        SysUser normalUser = new SysUser();
+        normalUser.setUsername("zhangsan");
+        SysRole operatorRole = new SysRole();
+        operatorRole.setRoleCode("OPERATOR");
+        normalUser.setRoles(Set.of(operatorRole));
+
+        when(authService.validateToken("valid-jwt")).thenReturn("zhangsan");
+        when(userRepository.findByUsername("zhangsan")).thenReturn(java.util.Optional.of(normalUser));
+        when(auditLogService.queryMyHistory(eq("zhangsan"), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
+
+        mockMvc.perform(get("/api/my-history")
+                        .cookie(new jakarta.servlet.http.Cookie("zhenduanqi_token", "valid-jwt")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.content").isEmpty());
+    }
+}


### PR DESCRIPTION
## 功能说明

实现 US10：用户查看自己的诊断历史。

### 验收标准完成情况

#### Happy Path
- [x] 可以查看自己的执行历史列表
- [x] 历史记录包含：执行时间、服务器、命令、结果
- [x] 可以查看历史执行的详细结果（展开详情）
- [x] 历史按时间倒序排列

#### 边界条件
- [x] 无历史记录时显示空状态
- [x] 支持分页
- [x] 支持按服务器筛选

#### 异常场景
- [x] 只能查看自己的历史，不能查看他人（API 层面强制 username 过滤）
- [x] 历史记录加载失败时显示错误提示

## 技术实现

### 后端
- 新增 `GET /api/my-history` API，所有已认证用户可访问
- 基于 `SysAuditLog` 表，按 username 过滤当前用户的记录

### 前端
- 新增 `MyHistory.vue` 页面
- 添加导航菜单入口 "我的历史"
- 支持按操作类型、目标服务器、时间范围筛选

## Playwright 验证结果

```
✅ Login successful
📸 Screenshot saved to /tmp/my_history_page.png
✅ MyHistory page title is visible
✅ History table is visible
   Table headers: ['执行时间', '服务器', '命令', '结果', '耗时(ms)', '详情']
✅ Navigation menu has '我的历史' item
✅ Filter '操作类型' is visible
✅ Filter '目标服务器' is visible

✅ All tests passed!
```

Closes #115