### PR TITLE
[P1] US3 验收 — 场景分类列表展示 (#124)

### DIFF
--- a/frontend/src/views/SceneList.vue
+++ b/frontend/src/views/SceneList.vue
@@ -26,19 +26,6 @@
             <el-icon><Search /></el-icon>
           </template>
         </el-input>
-        <el-select
-          v-model="selectedCategory"
-          placeholder="全部分类"
-          clearable
-          style="width: 160px"
-          @change="handleCategoryChange"
-        >
-          <el-option label="线程问题" value="THREAD" />
-          <el-option label="内存问题" value="MEMORY" />
-          <el-option label="JVM 基础" value="JVM" />
-          <el-option label="方法调试" value="METHOD" />
-          <el-option label="类加载问题" value="CLASSLOADER" />
-        </el-select>
       </div>
     </div>
 
@@ -51,47 +38,49 @@
         <p style="margin-top: 16px">暂无场景数据</p>
       </div>
 
-      <el-row :gutter="20" v-else>
-        <el-col
-          v-for="scene in filteredScenes"
-          :key="scene.id"
-          :xs="24"
-          :sm="12"
-          :md="8"
-          :lg="6"
-          style="margin-bottom: 20px"
-        >
-          <el-card
-            class="scene-card"
-            :body-style="{ padding: '0' }"
-            shadow="hover"
-            @click="enterScene(scene)"
-          >
-            <div
-              class="scene-card-header"
-              :style="{ backgroundColor: getCategoryColor(scene.category) }"
-            >
-              <el-icon :size="28" style="color: white">
-                <component :is="getCategoryIcon(scene.category)" />
+      <div v-else>
+        <div v-for="category in visibleCategories" :key="category.code" class="category-section">
+          <div class="category-header">
+            <div class="category-icon" :style="{ backgroundColor: category.color }">
+              <el-icon :size="24" style="color: white">
+                <component :is="category.icon" />
               </el-icon>
             </div>
-            <div class="scene-card-body">
-              <h3 class="scene-title">{{ scene.name }}</h3>
-              <p class="scene-desc">{{ scene.description || '暂无描述' }}</p>
-              <div class="scene-meta">
-                <el-tag size="small" :type="getCategoryTagType(scene.category)">
-                  {{ getCategoryName(scene.category) }}
-                </el-tag>
-                <span class="step-count">{{ scene.stepCount || 0 }} 个步骤</span>
-              </div>
-              <p v-if="scene.businessScenario" class="scene-business">
-                <el-icon><Location /></el-icon>
-                {{ scene.businessScenario }}
-              </p>
+            <div class="category-info">
+              <h3 class="category-name">{{ category.name }}</h3>
+              <p class="category-desc">{{ category.description }}</p>
             </div>
-          </el-card>
-        </el-col>
-      </el-row>
+          </div>
+          <el-row :gutter="16">
+            <el-col
+              v-for="scene in getScenesByCategory(category.code)"
+              :key="scene.id"
+              :xs="24"
+              :sm="12"
+              :md="8"
+              :lg="6"
+              style="margin-bottom: 16px"
+            >
+              <el-card
+                class="scene-card"
+                :body-style="{ padding: '16px' }"
+                shadow="hover"
+                @click="enterScene(scene)"
+              >
+                <h4 class="scene-title">{{ scene.name }}</h4>
+                <p class="scene-desc">{{ scene.description || '暂无描述' }}</p>
+                <div class="scene-meta">
+                  <span class="step-count">{{ scene.stepCount || 0 }} 个步骤</span>
+                </div>
+                <p v-if="scene.businessScenario" class="scene-business">
+                  <el-icon><Location /></el-icon>
+                  {{ scene.businessScenario }}
+                </p>
+              </el-card>
+            </el-col>
+          </el-row>
+        </div>
+      </div>
     </div>
 
     <el-dialog
@@ -147,25 +136,50 @@ const diagnoseStore = useDiagnoseStore();
 const loading = ref(false);
 const scenes = ref([]);
 const searchKeyword = ref('');
-const selectedCategory = ref('');
 const showServerDialog = ref(false);
 const selectedServerId = ref('');
 const pendingScene = ref(null);
 
-const categoryMap = {
-  THREAD: { name: '线程问题', color: '#409EFF', tagType: '' },
-  MEMORY: { name: '内存问题', color: '#67C23A', tagType: 'success' },
-  JVM: { name: 'JVM 基础', color: '#E6A23C', tagType: 'warning' },
-  METHOD: { name: '方法调试', color: '#9B59B6', tagType: 'info' },
-  CLASSLOADER: { name: '类加载问题', color: '#F56C6C', tagType: 'danger' },
-};
+const categoryDefinitions = [
+  {
+    code: 'THREAD',
+    name: '线程问题',
+    description: '死锁、CPU飙高等',
+    color: '#409EFF',
+    icon: Odometer,
+  },
+  {
+    code: 'MEMORY',
+    name: '内存问题',
+    description: 'OOM、内存泄漏、GC频繁等',
+    color: '#67C23A',
+    icon: DataAnalysis,
+  },
+  {
+    code: 'JVM',
+    name: 'JVM 基础',
+    description: '配置确认、环境信息等',
+    color: '#E6A23C',
+    icon: Box,
+  },
+  {
+    code: 'METHOD',
+    name: '方法调试',
+    description: '耗时追踪、调用监控等',
+    color: '#9B59B6',
+    icon: Monitor,
+  },
+  {
+    code: 'CLASSLOADER',
+    name: '类加载问题',
+    description: '类冲突、ClassNotFoundException等',
+    color: '#F56C6C',
+    icon: Connection,
+  },
+];
 
 const filteredScenes = computed(() => {
   let result = scenes.value;
-
-  if (selectedCategory.value) {
-    result = result.filter((s) => s.category === selectedCategory.value);
-  }
 
   if (searchKeyword.value) {
     const keyword = searchKeyword.value.toLowerCase();
@@ -180,27 +194,17 @@ const filteredScenes = computed(() => {
   return result;
 });
 
-function getCategoryName(category) {
-  return categoryMap[category]?.name || category;
-}
+const visibleCategories = computed(() => {
+  return categoryDefinitions.filter((cat) => {
+    const scenesInCategory = filteredScenes.value.filter((s) => s.category === cat.code);
+    return scenesInCategory.length > 0;
+  });
+});
 
-function getCategoryColor(category) {
-  return categoryMap[category]?.color || '#909399';
-}
-
-function getCategoryTagType(category) {
-  return categoryMap[category]?.tagType || '';
-}
-
-function getCategoryIcon(category) {
-  const iconMap = {
-    THREAD: Odometer,
-    MEMORY: DataAnalysis,
-    JVM: Box,
-    METHOD: Monitor,
-    CLASSLOADER: Connection,
-  };
-  return iconMap[category] || Folder;
+function getScenesByCategory(categoryCode) {
+  return filteredScenes.value
+    .filter((s) => s.category === categoryCode)
+    .sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
 }
 
 async function fetchScenes() {
@@ -217,7 +221,7 @@ async function fetchScenes() {
         }
       })
     );
-    scenes.value = scenesWithSteps;
+    scenes.value = scenesWithSteps.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0));
   } catch (e) {
     ElMessage.error('加载场景列表失败');
   } finally {
@@ -226,8 +230,6 @@ async function fetchScenes() {
 }
 
 function handleSearch() {}
-
-function handleCategoryChange() {}
 
 function enterScene(scene) {
   pendingScene.value = scene;
@@ -261,33 +263,64 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.category-section {
+  margin-bottom: 32px;
+}
+
+.category-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #ebeef5;
+}
+
+.category-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.category-info {
+  flex: 1;
+}
+
+.category-name {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #303133;
+}
+
+.category-desc {
+  margin: 4px 0 0 0;
+  font-size: 13px;
+  color: #909399;
+}
+
 .scene-card {
   cursor: pointer;
   transition:
     transform 0.2s,
     box-shadow 0.2s;
   height: 100%;
+  border: 1px solid #ebeef5;
 }
 
 .scene-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
-}
-
-.scene-card-header {
-  height: 80px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.scene-card-body {
-  padding: 16px;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-color: #409eff;
 }
 
 .scene-title {
   margin: 0 0 8px 0;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   color: #303133;
   line-height: 1.4;


### PR DESCRIPTION
## Summary

实现场景列表按分类分组展示功能。

### 验收标准完成情况

#### Happy Path
- [x] 场景列表按分类展示（THREAD/MEMORY/JVM/METHOD/CLASSLOADER）
- [x] 每个分类显示分类名称和图标
- [x] 每个场景显示场景名称和描述
- [x] 可以点击场景进入诊断页面

#### 边界条件
- [x] 无场景时显示空状态
- [x] 分类下无场景时不显示该分类
- [x] 场景列表支持排序（sort_order）

#### 异常场景
- [x] 场景列表加载失败时显示错误提示
- [x] 未登录用户访问场景列表，重定向到登录页

### 验证截图

Playwright 自动化测试通过，截图保存在 `/tmp/scene-test/` 目录：
- 空状态显示正常
- 服务器选择对话框正常弹出

### Changes

- 移除分类下拉筛选框（改为按分类分组展示）
- 添加分类区块样式（图标 + 名称 + 描述）
- 实现分类自动过滤（无场景的分类不显示）
- 场景卡片简化（移除分类标签，因为已在分类区块内）

Closes #124