### PR TITLE
[P0] US16 验收 — 只读用户权限 (#105)

### DIFF
--- a/frontend/src/views/SceneDiagnose.vue
+++ b/frontend/src/views/SceneDiagnose.vue
@@ -77,7 +77,10 @@
             >
               <template #append>
                 <el-button
-                  v-if="!step.continuous"
+                  v-if="
+                    !step.continuous &&
+                    (userStore.role === 'OPERATOR' || userStore.role === 'ADMIN')
+                  "
                   :loading="stepStates[index]?.state === 'executing'"
                   :disabled="
                     !diagnoseStore.selectedServerId || stepStates[index]?.state === 'executing'
@@ -87,7 +90,11 @@
                   <el-icon v-if="!stepStates[index]?.state"><VideoPlay /></el-icon>
                   执行
                 </el-button>
-                <template v-else>
+                <template
+                  v-else-if="
+                    step.continuous && (userStore.role === 'OPERATOR' || userStore.role === 'ADMIN')
+                  "
+                >
                   <el-button
                     v-if="stepStates[index]?.state !== 'executing'"
                     :disabled="!diagnoseStore.selectedServerId"
@@ -101,6 +108,7 @@
                     停止
                   </el-button>
                 </template>
+                <el-tag v-else type="info" size="small">只读</el-tag>
               </template>
             </el-input>
             <div
@@ -231,12 +239,14 @@ import {
 } from '../api';
 import { useDiagnoseStore } from '../stores/diagnose';
 import { useServerStore } from '../stores/servers';
+import { useUserStore } from '../stores/user';
 import { getRenderer } from '../components/ResultRenderer';
 
 const router = useRouter();
 const route = useRoute();
 const diagnoseStore = useDiagnoseStore();
 const serverStore = useServerStore();
+const userStore = useUserStore();
 
 const stepCommands = ref([]);
 const stepStates = ref([]);

--- a/src/main/java/com/zhenduanqi/config/DefaultAdminInitializer.java
+++ b/src/main/java/com/zhenduanqi/config/DefaultAdminInitializer.java
@@ -41,16 +41,58 @@ public class DefaultAdminInitializer implements CommandLineRunner {
             admin.setRealName("系统管理员");
             admin.setStatus("ACTIVE");
 
-            Set<SysRole> roles = new HashSet<>();
+            Set<SysRole> adminRoles = new HashSet<>();
             roleRepository.findByRoleCode("ADMIN").ifPresentOrElse(
-                    roles::add,
+                    adminRoles::add,
                     () -> log.warn("ADMIN role not found, user will have no roles")
             );
-            admin.setRoles(roles);
+            admin.setRoles(adminRoles);
 
             userRepository.save(admin);
             log.info("Default admin user created successfully with roles: {}", 
-                    roles.stream().map(SysRole::getRoleCode).toList());
+                    adminRoles.stream().map(SysRole::getRoleCode).toList());
+        }
+
+        if (userRepository.findByUsername("readonly").isEmpty()) {
+            log.info("Creating default readonly user...");
+
+            SysUser readonly = new SysUser();
+            readonly.setUsername("readonly");
+            readonly.setPassword(passwordEncoder.encode("Abcd1234"));
+            readonly.setRealName("只读用户");
+            readonly.setStatus("ACTIVE");
+
+            Set<SysRole> readonlyRoles = new HashSet<>();
+            roleRepository.findByRoleCode("READONLY").ifPresentOrElse(
+                    readonlyRoles::add,
+                    () -> log.warn("READONLY role not found, user will have no roles")
+            );
+            readonly.setRoles(readonlyRoles);
+
+            userRepository.save(readonly);
+            log.info("Default readonly user created successfully with roles: {}", 
+                    readonlyRoles.stream().map(SysRole::getRoleCode).toList());
+        }
+
+        if (userRepository.findByUsername("operator").isEmpty()) {
+            log.info("Creating default operator user...");
+
+            SysUser operator = new SysUser();
+            operator.setUsername("operator");
+            operator.setPassword(passwordEncoder.encode("Abcd1234"));
+            operator.setRealName("操作员");
+            operator.setStatus("ACTIVE");
+
+            Set<SysRole> operatorRoles = new HashSet<>();
+            roleRepository.findByRoleCode("OPERATOR").ifPresentOrElse(
+                    operatorRoles::add,
+                    () -> log.warn("OPERATOR role not found, user will have no roles")
+            );
+            operator.setRoles(operatorRoles);
+
+            userRepository.save(operator);
+            log.info("Default operator user created successfully with roles: {}", 
+                    operatorRoles.stream().map(SysRole::getRoleCode).toList());
         }
     }
 }


### PR DESCRIPTION
## 实现内容

### 后端权限控制
- 所有 API 已有正确的 `@RequireRole` 注解
- `RoleAspect` 正确拦截未授权请求返回 403

### 前端权限控制
- `SceneDiagnose.vue` 添加执行按钮权限控制
- 只读用户在场景诊断页面看到"只读"标签，无法执行命令
- `App.vue` 菜单已正确隐藏管理功能（服务器管理、用户管理、审计日志、命令守卫、会话管理）
- `ServerList.vue` 添加/编辑/删除按钮已对非管理员隐藏
- `Diagnose.vue` 执行按钮已对只读用户隐藏

### 测试用户
系统启动时自动创建三种角色的测试用户：
- `admin` / `Abcd1234` - 管理员
- `operator` / `Abcd1234` - 操作员
- `readonly` / `Abcd1234` - 只读用户

## 验收标准检查

### Happy Path
- [x] 只读用户可以登录系统
- [x] 只读用户可以查看服务器列表
- [x] 只读用户可以查看服务器详情
- [x] 只读用户可以查看场景列表
- [x] 只读用户可以查看场景步骤
- [x] 只读用户可以查看执行结果

### 边界条件
- [x] 只读用户看不到服务器管理按钮
- [x] 只读用户看不到用户管理菜单
- [x] 只读用户看不到审计日志菜单
- [x] 只读用户看不到命令守卫菜单
- [x] 只读用户看不到会话管理菜单

### 异常场景
- [x] 只读用户尝试执行命令，返回 403
- [x] 只读用户尝试创建/编辑/删除服务器，返回 403
- [x] 只读用户尝试创建/编辑/删除用户，返回 403
- [x] 只读用户尝试创建/编辑/删除场景，返回 403
- [x] 只读用户直接调用 API 时返回 403

Closes #105