### PR TITLE
[P1] US5 验收 — 场景5 JVM基础信息渲染器 (#131)

### DIFF
--- a/frontend/src/components/ResultRenderer/DashboardRenderer.vue
+++ b/frontend/src/components/ResultRenderer/DashboardRenderer.vue
@@ -1,0 +1,229 @@
+<template>
+  <div class="dashboard-renderer">
+    <div v-if="hasData" class="dashboard-content">
+      <el-tabs type="border-card" size="small">
+        <el-tab-pane label="线程">
+          <el-table :data="threadData" stripe size="small" max-height="200">
+            <el-table-column prop="name" label="线程名" min-width="150" />
+            <el-table-column prop="status" label="状态" width="100">
+              <template #default="{ row }">
+                <el-tag size="small" :type="getStatusType(row.status)">
+                  {{ row.status }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column prop="cpu" label="CPU%" width="70" align="right">
+              <template #default="{ row }">
+                {{ row.cpu != null ? row.cpu.toFixed(1) : '-' }}
+              </template>
+            </el-table-column>
+            <el-table-column prop="deltaTime" label="Delta(ms)" width="90" align="right">
+              <template #default="{ row }">
+                {{ row.deltaTime != null ? row.deltaTime : '-' }}
+              </template>
+            </el-table-column>
+            <el-table-column prop="threadId" label="线程ID" width="80" align="center" />
+          </el-table>
+        </el-tab-pane>
+
+        <el-tab-pane label="内存">
+          <el-table :data="memoryData" stripe size="small">
+            <el-table-column prop="name" label="区域" min-width="120" />
+            <el-table-column prop="used" label="已用" width="100" align="right">
+              <template #default="{ row }">
+                {{ formatBytes(row.used) }}
+              </template>
+            </el-table-column>
+            <el-table-column prop="total" label="总量" width="100" align="right">
+              <template #default="{ row }">
+                {{ formatBytes(row.total) }}
+              </template>
+            </el-table-column>
+            <el-table-column label="使用率" width="150">
+              <template #default="{ row }">
+                <div style="display: flex; align-items: center; gap: 8px">
+                  <el-progress
+                    :percentage="getPercentage(row)"
+                    :color="getProgressColor(row)"
+                    :stroke-width="8"
+                    style="flex: 1"
+                  />
+                  <span style="width: 35px; text-align: right">{{ getPercentage(row) }}%</span>
+                </div>
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-tab-pane>
+
+        <el-tab-pane label="GC">
+          <el-table :data="gcData" stripe size="small">
+            <el-table-column prop="name" label="GC收集器" min-width="150" />
+            <el-table-column prop="count" label="次数" width="80" align="center" />
+            <el-table-column prop="time" label="耗时(ms)" width="100" align="right">
+              <template #default="{ row }">
+                {{ row.time != null ? row.time : '-' }}
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-tab-pane>
+      </el-tabs>
+    </div>
+
+    <div v-else class="dashboard-empty">
+      <el-empty description="暂无 dashboard 数据" :image-size="60" />
+    </div>
+
+    <div
+      v-if="isExample"
+      style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic"
+    >
+      (示例数据)
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  data: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const defaultData = {
+  threads: [
+    { name: 'main', status: 'RUNNABLE', cpu: 0.5, deltaTime: 100, threadId: 1 },
+    { name: 'gc-thread-1', status: 'WAITING', cpu: 0.0, deltaTime: 50, threadId: 2 },
+    { name: 'http-nio-8080-exec-1', status: 'BLOCKED', cpu: 2.3, deltaTime: 200, threadId: 15 },
+  ],
+  memory: [
+    { name: 'Heap Memory', used: 268435456, total: 536870912 },
+    { name: 'Eden Space', used: 134217728, total: 268435456 },
+    { name: 'Survivor Space', used: 16777216, total: 33554432 },
+    { name: 'Old Gen', used: 117440512, total: 268435456 },
+  ],
+  gc: [
+    { name: 'Copy', count: 15, time: 120 },
+    { name: 'MarkSweepCompact', count: 3, time: 80 },
+  ],
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const hasData = computed(() => {
+  return (
+    currentData.value &&
+    (currentData.value.threads?.length ||
+      currentData.value.memory?.length ||
+      currentData.value.gc?.length)
+  );
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
+const threadData = computed(() => {
+  if (currentData.value?.threads) {
+    return currentData.value.threads.map(normalizeThread);
+  }
+  if (currentData.value?.threadList) {
+    return currentData.value.threadList.map(normalizeThread);
+  }
+  return [];
+});
+
+const memoryData = computed(() => {
+  if (currentData.value?.memory) {
+    return normalizeMemoryData(currentData.value.memory);
+  }
+  return [];
+});
+
+const gcData = computed(() => {
+  if (currentData.value?.gc) {
+    return normalizeGcData(currentData.value.gc);
+  }
+  return [];
+});
+
+function normalizeThread(thread) {
+  return {
+    name: thread.name,
+    status: thread.state || thread.status,
+    cpu: thread.cpu,
+    deltaTime: thread.deltaTime,
+    threadId: thread.id || thread.threadId,
+  };
+}
+
+function normalizeMemoryData(memory) {
+  if (Array.isArray(memory)) {
+    return memory;
+  }
+  return Object.entries(memory).map(([name, info]) => ({
+    name,
+    used: info.used,
+    total: info.total,
+  }));
+}
+
+function normalizeGcData(gc) {
+  if (Array.isArray(gc)) {
+    return gc;
+  }
+  return Object.entries(gc).map(([name, info]) => ({
+    name,
+    count: info.count,
+    time: info.time,
+  }));
+}
+
+function formatBytes(bytes) {
+  if (!bytes) return '-';
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  if (bytes < 1024 * 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+  return (bytes / 1024 / 1024 / 1024).toFixed(2) + ' GB';
+}
+
+function getPercentage(row) {
+  if (!row.total || row.total === 0) return 0;
+  return Math.round((row.used / row.total) * 100);
+}
+
+function getProgressColor(row) {
+  const pct = getPercentage(row);
+  if (pct >= 90) return '#f56c6c';
+  if (pct >= 70) return '#e6a23c';
+  return '#67c23a';
+}
+
+function getStatusType(status) {
+  if (status === 'RUNNABLE') return 'success';
+  if (status === 'BLOCKED') return 'danger';
+  if (status === 'WAITING' || status === 'TIMED_WAITING') return 'warning';
+  return 'info';
+}
+</script>
+
+<style scoped>
+.dashboard-renderer {
+  width: 100%;
+}
+
+.dashboard-content {
+  width: 100%;
+}
+
+.dashboard-empty {
+  padding: 20px;
+}
+</style>

--- a/frontend/src/components/ResultRenderer/SysenvRenderer.vue
+++ b/frontend/src/components/ResultRenderer/SysenvRenderer.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <el-table :data="tableData" stripe size="small" max-height="400">
+      <el-table-column prop="key" label="变量名" min-width="250">
+        <template #default="{ row }">
+          <span style="font-weight: 500; color: #409eff">{{ row.key }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="value" label="值" min-width="300">
+        <template #default="{ row }">
+          <span style="word-break: break-all">{{ row.value }}</span>
+        </template>
+      </el-table-column>
+    </el-table>
+    <div
+      v-if="isExample"
+      style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic"
+    >
+      (示例数据)
+    </div>
+    <div v-if="tableData.length > 0" style="margin-top: 8px; font-size: 12px; color: #909399">
+      共 {{ tableData.length }} 个环境变量
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  data: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const defaultData = {
+  env: {
+    JAVA_HOME: '/usr/lib/jvm/java-17',
+    PATH: '/usr/local/bin:/usr/bin:/bin',
+    USER: 'admin',
+    LANG: 'en_US.UTF-8',
+    JAVA_OPTS: '-Xms512m -Xmx2048m',
+    CATALINA_HOME: '/opt/tomcat',
+    SERVER_PORT: '8080',
+    OS_NAME: 'Linux',
+    OS_VERSION: '5.4.0-generic',
+    OS_ARCH: 'amd64',
+  },
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
+const tableData = computed(() => {
+  if (currentData.value?.env) {
+    return normalizeEnvData(currentData.value.env);
+  }
+  if (Array.isArray(currentData.value)) {
+    return normalizeEnvData(currentData.value);
+  }
+  if (typeof currentData.value === 'object') {
+    return normalizeEnvData(currentData.value);
+  }
+  return [];
+});
+
+function normalizeEnvData(env) {
+  if (Array.isArray(env)) {
+    return env.map((item) => {
+      if (typeof item === 'string') {
+        const parts = item.split('=');
+        return {
+          key: parts[0] || item,
+          value: parts.slice(1).join('=') || '-',
+        };
+      }
+      return {
+        key: item.name || item.key || item.variable || '-',
+        value: item.value || item.val || '-',
+      };
+    });
+  }
+  if (typeof env === 'object') {
+    return Object.entries(env)
+      .map(([key, value]) => ({
+        key,
+        value: value != null ? String(value) : '-',
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key));
+  }
+  return [];
+}
+</script>

--- a/frontend/src/components/ResultRenderer/VmoptionRenderer.vue
+++ b/frontend/src/components/ResultRenderer/VmoptionRenderer.vue
@@ -24,7 +24,7 @@
           <el-tag v-if="row.origin && row.origin !== row.value" size="small" type="warning">
             修改
           </el-tag>
-          <el-tag v-else size="small" type="info"> 默认 </el-tag>
+          <el-tag v-else size="small" type="info">默认</el-tag>
         </template>
       </el-table-column>
     </el-table>

--- a/frontend/src/components/ResultRenderer/VmoptionRenderer.vue
+++ b/frontend/src/components/ResultRenderer/VmoptionRenderer.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <el-table :data="tableData" stripe size="small" max-height="400">
+      <el-table-column prop="name" label="参数名" min-width="200">
+        <template #default="{ row }">
+          <span style="font-weight: 500; color: #409eff">{{ row.name }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="value" label="当前值" min-width="150">
+        <template #default="{ row }">
+          <span style="color: #67c23a">{{ row.value }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column prop="origin" label="默认值" min-width="150">
+        <template #default="{ row }">
+          <span v-if="row.origin && row.origin !== row.value" style="color: #909399">
+            {{ row.origin }}
+          </span>
+          <span v-else style="color: #c0c4cc">-</span>
+        </template>
+      </el-table-column>
+      <el-table-column label="类型" width="80" align="center">
+        <template #default="{ row }">
+          <el-tag v-if="row.origin && row.origin !== row.value" size="small" type="warning">
+            修改
+          </el-tag>
+          <el-tag v-else size="small" type="info"> 默认 </el-tag>
+        </template>
+      </el-table-column>
+    </el-table>
+    <div
+      v-if="isExample"
+      style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic"
+    >
+      (示例数据)
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  data: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const defaultData = {
+  options: [
+    { name: '-XX:+UseG1GC', value: 'true', origin: 'true' },
+    { name: '-XX:MaxGCPauseMillis', value: '200', origin: '200' },
+    { name: '-XX:+UseStringDeduplication', value: 'true', origin: 'false' },
+    { name: '-Xms512m', value: '512m', origin: '512m' },
+    { name: '-Xmx2048m', value: '2048m', origin: '1024m' },
+    { name: '-XX:NewRatio', value: '2', origin: '2' },
+  ],
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
+const tableData = computed(() => {
+  if (currentData.value?.options) {
+    return normalizeOptionsData(currentData.value.options);
+  }
+  if (Array.isArray(currentData.value)) {
+    return normalizeOptionsData(currentData.value);
+  }
+  return [];
+});
+
+function normalizeOptionsData(options) {
+  if (Array.isArray(options)) {
+    return options.map((opt) => {
+      if (typeof opt === 'string') {
+        const parts = opt.split('=');
+        return {
+          name: parts[0] || opt,
+          value: parts[1] || '-',
+          origin: parts[1] || '-',
+        };
+      }
+      return {
+        name: opt.name || opt.key || opt.option || opt.parameter || '-',
+        value: opt.value || opt.current || opt.currentValue || '-',
+        origin: opt.origin || opt.default || opt.originValue || '-',
+      };
+    });
+  }
+  return [];
+}
+</script>

--- a/frontend/src/components/ResultRenderer/index.js
+++ b/frontend/src/components/ResultRenderer/index.js
@@ -3,16 +3,31 @@ import MemoryRenderer from './MemoryRenderer.vue';
 import StatusRenderer from './StatusRenderer.vue';
 import EnhancerRenderer from './EnhancerRenderer.vue';
 import FallbackRenderer from './FallbackRenderer.vue';
+import DashboardRenderer from './DashboardRenderer.vue';
+import VmoptionRenderer from './VmoptionRenderer.vue';
+import SysenvRenderer from './SysenvRenderer.vue';
 
 const rendererMap = {
   thread: ThreadRenderer,
   memory: MemoryRenderer,
   status: StatusRenderer,
   enhancer: EnhancerRenderer,
+  dashboard: DashboardRenderer,
+  vmoption: VmoptionRenderer,
+  sysenv: SysenvRenderer,
 };
 
 export function getRenderer(type) {
   return rendererMap[type] || FallbackRenderer;
 }
 
-export { ThreadRenderer, MemoryRenderer, StatusRenderer, EnhancerRenderer, FallbackRenderer };
+export {
+  ThreadRenderer,
+  MemoryRenderer,
+  StatusRenderer,
+  EnhancerRenderer,
+  FallbackRenderer,
+  DashboardRenderer,
+  VmoptionRenderer,
+  SysenvRenderer,
+};


### PR DESCRIPTION
## 功能描述
场景5（JVM基础信息）需要支持以下 Arthas 命令的结果渲染：
- dashboard -n 1: JVM概览
- vmoption: JVM参数
- sysenv: 系统环境变量

## 改动内容
### 新增渲染器
1. **DashboardRenderer.vue**: 展示 JVM 概览数据，包含线程、内存、GC 三个 Tab 页签
2. **VmoptionRenderer.vue**: 以表格形式展示 JVM 参数，含参数名、当前值、默认值、修改标记
3. **SysenvRenderer.vue**: 以键值对表格形式展示系统环境变量

### 渲染器注册
- 在 index.js 中注册 dashboard、vmoption、sysenv 三种 result type

## 验收标准
- [x] dashboard 结果包含线程、内存、GC 信息，以 Tab 页签展示
- [x] vmoption 结果以表格形式展示，含修改标记
- [x] sysenv 结果以键值对形式展示
- [x] 前端构建通过

## 验证方式
1. 本地启动后端 (mvn spring-boot:run)
2. 登录系统，选择服务器
3. 进入场景列表 → JVM基础信息
4. 执行三个步骤，确认结果正确渲染

Closes #131