### PR TITLE
[P1] US4 验收 — 业务场景关键词检索 (#125)

### DIFF
--- a/frontend/src/views/SceneList.vue
+++ b/frontend/src/views/SceneList.vue
@@ -35,7 +35,12 @@
         style="text-align: center; padding: 60px 0; color: #909399"
       >
         <el-icon :size="48"><Folder /></el-icon>
-        <p style="margin-top: 16px">暂无场景数据</p>
+        <p style="margin-top: 16px">
+          {{ searchKeyword ? `未找到与"${searchKeyword}"相关的场景` : '暂无场景数据' }}
+        </p>
+        <p v-if="searchKeyword" style="margin-top: 8px; font-size: 13px">
+          请尝试其他关键词
+        </p>
       </div>
 
       <div v-else>
@@ -67,14 +72,14 @@
                 shadow="hover"
                 @click="enterScene(scene)"
               >
-                <h4 class="scene-title">{{ scene.name }}</h4>
-                <p class="scene-desc">{{ scene.description || '暂无描述' }}</p>
+                <h4 class="scene-title" v-html="highlightText(scene.name)"></h4>
+                <p class="scene-desc" v-html="highlightText(scene.description || '暂无描述')"></p>
                 <div class="scene-meta">
                   <span class="step-count">{{ scene.stepCount || 0 }} 个步骤</span>
                 </div>
                 <p v-if="scene.businessScenario" class="scene-business">
                   <el-icon><Location /></el-icon>
-                  {{ scene.businessScenario }}
+                  <span v-html="highlightText(scene.businessScenario)"></span>
                 </p>
               </el-card>
             </el-col>
@@ -231,6 +236,19 @@ async function fetchScenes() {
 
 function handleSearch() {}
 
+function highlightText(text) {
+  if (!text) return '';
+  if (!searchKeyword.value) return text;
+  
+  const keyword = searchKeyword.value;
+  const regex = new RegExp(`(${escapeRegExp(keyword)})`, 'gi');
+  return text.replace(regex, '<mark class="highlight">$1</mark>');
+}
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function enterScene(scene) {
   pendingScene.value = scene;
   selectedServerId.value = diagnoseStore.selectedServerId || '';
@@ -361,5 +379,12 @@ onMounted(() => {
 
 .scene-business .el-icon {
   flex-shrink: 0;
+}
+
+:deep(.highlight) {
+  background-color: #fef0f0;
+  color: #f56c6c;
+  padding: 0 2px;
+  border-radius: 2px;
 }
 </style>

--- a/frontend/src/views/SceneList.vue
+++ b/frontend/src/views/SceneList.vue
@@ -38,9 +38,7 @@
         <p style="margin-top: 16px">
           {{ searchKeyword ? `未找到与"${searchKeyword}"相关的场景` : '暂无场景数据' }}
         </p>
-        <p v-if="searchKeyword" style="margin-top: 8px; font-size: 13px">
-          请尝试其他关键词
-        </p>
+        <p v-if="searchKeyword" style="margin-top: 8px; font-size: 13px">请尝试其他关键词</p>
       </div>
 
       <div v-else>
@@ -239,7 +237,7 @@ function handleSearch() {}
 function highlightText(text) {
   if (!text) return '';
   if (!searchKeyword.value) return text;
-  
+
   const keyword = searchKeyword.value;
   const regex = new RegExp(`(${escapeRegExp(keyword)})`, 'gi');
   return text.replace(regex, '<mark class="highlight">$1</mark>');


### PR DESCRIPTION
Closes #125

## 实现内容

### 功能增强
- 搜索结果高亮显示匹配关键词
- 无匹配结果时显示友好的空状态提示

### 验收标准完成情况

#### Happy Path
- [x] 场景列表页有搜索框（已存在）
- [x] 输入关键词可以搜索场景（已存在）
- [x] 搜索匹配场景名称和 business_scenario 字段（已存在）
- [x] 搜索结果高亮显示匹配内容（新增）

#### 边界条件
- [x] 搜索支持中英文（已存在）
- [x] 搜索不区分大小写（已存在）
- [x] 空搜索词显示全部场景（已存在）

#### 异常场景
- [x] 无匹配结果时显示空状态（新增）
- [x] 搜索失败时显示错误提示（已存在）

## Playwright 验证截图

测试结果：
- 搜索 '死锁'：找到匹配场景，2个高亮元素
- 搜索 'CPU'：正常工作
- 搜索不存在的关键词：显示空状态提示 '未找到与"xyz123notexist"相关的场景'
- 清空搜索：恢复显示所有场景
- 大小写不敏感搜索 'thread'：正常工作

截图保存在 /tmp/ 目录：
- issue125_03_scene_list.png - 场景列表页
- issue125_04_search_deadlock.png - 搜索'死锁'结果
- issue125_05_search_cpu.png - 搜索'CPU'结果
- issue125_06_search_not_found.png - 无结果空状态