### PR TITLE
[P2] US23 验收 — 活跃会话管理 (#135)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -581,7 +581,7 @@ CREATE TABLE arthas_session (
 | 方法 | 路径 | 说明 | 角色 |
 |------|------|------|------|
 | POST | `/api/arthas-sessions` | 创建 Arthas 会话并执行命令 | OPERATOR, ADMIN |
-| GET | `/api/arthas-sessions?serverId=&sceneId=` | 查询活跃会话（用于刷新恢复和管理） | 已认证 |
+| GET | `/api/arthas-sessions?serverId=&username=` | 查询活跃会话（支持按服务器和用户筛选） | ADMIN |
 | GET | `/api/arthas-sessions/{id}/results` | 拉取增量结果 | OPERATOR, ADMIN |
 | POST | `/api/arthas-sessions/{id}/interrupt` | 中断当前命令 | OPERATOR, ADMIN |
 | POST | `/api/arthas-sessions/{id}/close` | 关闭会话（reset + close_session） | OPERATOR, ADMIN |

--- a/frontend/src/views/SessionManage.vue
+++ b/frontend/src/views/SessionManage.vue
@@ -1,5 +1,9 @@
 <template>
-  <div>
+  <div v-if="userStore.role !== 'ADMIN'" class="no-permission">
+    <el-result icon="error" title="权限不足" sub-title="只有管理员可以访问会话管理页面" />
+  </div>
+
+  <div v-else>
     <div
       style="
         display: flex;
@@ -12,9 +16,41 @@
       <el-button type="primary" @click="fetchSessions">刷新</el-button>
     </div>
 
+    <el-form :inline="true" :model="filters" class="filter-form">
+      <el-form-item label="服务器">
+        <el-select
+          v-model="filters.serverId"
+          placeholder="全部服务器"
+          clearable
+          @change="fetchSessions"
+        >
+          <el-option v-for="s in servers" :key="s.id" :label="s.name" :value="s.id" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="操作人">
+        <el-select
+          v-model="filters.username"
+          placeholder="全部用户"
+          clearable
+          @change="fetchSessions"
+        >
+          <el-option v-for="u in uniqueUsers" :key="u" :label="u" :value="u" />
+        </el-select>
+      </el-form-item>
+      <el-form-item>
+        <el-button @click="resetFilters">重置筛选</el-button>
+      </el-form-item>
+    </el-form>
+
     <el-table :data="sessions" v-loading="loading" stripe style="width: 100%">
       <el-table-column prop="id" label="会话ID" width="80" />
-      <el-table-column prop="serverId" label="服务器" width="120" />
+      <el-table-column label="服务器" width="200">
+        <template #default="{ row }">
+          <el-tooltip :content="row.serverId" placement="top">
+            <span class="truncate-text">{{ getServerName(row.serverId) || row.serverId }}</span>
+          </el-tooltip>
+        </template>
+      </el-table-column>
       <el-table-column prop="arthasSessionId" label="Arthas会话ID" width="200">
         <template #default="{ row }">
           <el-tooltip :content="row.arthasSessionId || '-'" placement="top">
@@ -22,7 +58,7 @@
           </el-tooltip>
         </template>
       </el-table-column>
-      <el-table-column prop="username" label="用户" width="100" />
+      <el-table-column prop="username" label="用户" width="120" />
       <el-table-column prop="status" label="状态" width="100">
         <template #default="{ row }">
           <el-tag
@@ -82,14 +118,21 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted } from 'vue';
 import { ElMessage, ElMessageBox } from 'element-plus';
+import { useUserStore } from '../stores/user';
+import { useServerStore } from '../stores/servers';
 import { getActiveSessions, interruptSessionJob, closeSession } from '../api';
 
+const userStore = useUserStore();
+const serverStore = useServerStore();
+
 const sessions = ref([]);
+const servers = ref([]);
 const loading = ref(false);
 const interruptingId = ref(null);
 const closingId = ref(null);
+const filters = ref({ serverId: '', username: '' });
 let refreshInterval = null;
 
 const statusTextMap = {
@@ -98,9 +141,26 @@ const statusTextMap = {
   CLOSED: '已关闭',
 };
 
-onMounted(() => {
-  fetchSessions();
-  refreshInterval = setInterval(fetchSessions, 30000);
+const uniqueUsers = computed(() => {
+  const users = new Set();
+  sessions.value.forEach((s) => {
+    if (s.username) users.add(s.username);
+  });
+  return Array.from(users);
+});
+
+function getServerName(serverId) {
+  const server = servers.value.find((s) => s.id === serverId);
+  return server ? server.name : serverId;
+}
+
+onMounted(async () => {
+  if (userStore.role === 'ADMIN') {
+    await serverStore.fetchServers();
+    servers.value = serverStore.list;
+    await fetchSessions();
+    refreshInterval = setInterval(fetchSessions, 30000);
+  }
 });
 
 onUnmounted(() => {
@@ -112,13 +172,25 @@ onUnmounted(() => {
 async function fetchSessions() {
   loading.value = true;
   try {
-    const res = await getActiveSessions();
+    const params = {};
+    if (filters.value.serverId) params.serverId = filters.value.serverId;
+    if (filters.value.username) params.username = filters.value.username;
+    const res = await getActiveSessions(params);
     sessions.value = res.data || [];
   } catch (e) {
-    ElMessage.error('获取会话列表失败: ' + (e.response?.data?.error || e.message));
+    if (e.response?.status === 403) {
+      ElMessage.error('权限不足，只有管理员可以访问会话管理');
+    } else {
+      ElMessage.error('获取会话列表失败: ' + (e.response?.data?.error || e.message));
+    }
   } finally {
     loading.value = false;
   }
+}
+
+function resetFilters() {
+  filters.value = { serverId: '', username: '' };
+  fetchSessions();
 }
 
 async function handleInterrupt(row) {
@@ -138,7 +210,11 @@ async function handleInterrupt(row) {
       ElMessage.error('中断失败');
     }
   } catch (e) {
-    ElMessage.error('中断失败: ' + (e.response?.data?.error || e.message));
+    if (e.response?.status === 404) {
+      ElMessage.error('会话不存在');
+    } else {
+      ElMessage.error('中断失败: ' + (e.response?.data?.error || e.message));
+    }
   } finally {
     interruptingId.value = null;
   }
@@ -164,7 +240,11 @@ async function handleClose(row) {
       ElMessage.error('关闭失败');
     }
   } catch (e) {
-    ElMessage.error('关闭失败: ' + (e.response?.data?.error || e.message));
+    if (e.response?.status === 404) {
+      ElMessage.error('会话不存在');
+    } else {
+      ElMessage.error('关闭失败: ' + (e.response?.data?.error || e.message));
+    }
   } finally {
     closingId.value = null;
   }
@@ -189,6 +269,17 @@ function formatDateTime(dateStr) {
 </script>
 
 <style scoped>
+.no-permission {
+  padding: 60px 20px;
+}
+
+.filter-form {
+  margin-bottom: 16px;
+  padding: 16px;
+  background: #f5f7fa;
+  border-radius: 4px;
+}
+
 .truncate-text {
   display: inline-block;
   max-width: 180px;

--- a/src/main/java/com/zhenduanqi/controller/ArthasSessionController.java
+++ b/src/main/java/com/zhenduanqi/controller/ArthasSessionController.java
@@ -34,8 +34,11 @@ public class ArthasSessionController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ArthasSessionDTO>> getActiveSessions(@RequestParam(required = false) String serverId) {
-        List<ArthasSessionDTO> sessions = sessionService.getActiveSessions(serverId);
+    @RequireRole("ADMIN")
+    public ResponseEntity<List<ArthasSessionDTO>> getActiveSessions(
+            @RequestParam(required = false) String serverId,
+            @RequestParam(required = false) String username) {
+        List<ArthasSessionDTO> sessions = sessionService.getActiveSessions(serverId, username);
         return ResponseEntity.ok(sessions);
     }
 
@@ -51,6 +54,9 @@ public class ArthasSessionController {
     @AuditLog(action = "中断 Arthas 任务")
     public ResponseEntity<Map<String, Boolean>> interruptJob(@PathVariable Long id) {
         boolean result = sessionService.interruptJob(id);
+        if (!result) {
+            return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok(Map.of("success", result));
     }
 
@@ -59,6 +65,9 @@ public class ArthasSessionController {
     @AuditLog(action = "关闭 Arthas 会话")
     public ResponseEntity<Map<String, Boolean>> closeSession(@PathVariable Long id) {
         boolean result = sessionService.closeSession(id);
+        if (!result) {
+            return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok(Map.of("success", result));
     }
 

--- a/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
+++ b/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
@@ -19,6 +19,8 @@ public interface ArthasSessionRepository extends JpaRepository<ArthasSession, Lo
 
     List<ArthasSession> findByUsernameAndStatusOrderByCreatedAtDesc(String username, String status);
 
+    List<ArthasSession> findByServerIdAndUsernameAndStatusOrderByCreatedAtDesc(String serverId, String username, String status);
+
     List<ArthasSession> findByStatusOrderByCreatedAtDesc(String status);
 
     Optional<ArthasSession> findByIdAndStatus(Long id, String status);

--- a/src/main/java/com/zhenduanqi/service/ArthasSessionService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasSessionService.java
@@ -89,10 +89,17 @@ public class ArthasSessionService {
         return ArthasSessionDTO.fromEntity(savedSession);
     }
 
-    public List<ArthasSessionDTO> getActiveSessions(String serverId) {
+    public List<ArthasSessionDTO> getActiveSessions(String serverId, String username) {
         List<ArthasSession> sessions;
-        if (serverId != null && !serverId.isEmpty()) {
+        boolean hasServerId = serverId != null && !serverId.isEmpty();
+        boolean hasUsername = username != null && !username.isEmpty();
+        
+        if (hasServerId && hasUsername) {
+            sessions = sessionRepository.findByServerIdAndUsernameAndStatusOrderByCreatedAtDesc(serverId, username, "ACTIVE");
+        } else if (hasServerId) {
             sessions = sessionRepository.findByServerIdAndStatusOrderByCreatedAtDesc(serverId, "ACTIVE");
+        } else if (hasUsername) {
+            sessions = sessionRepository.findByUsernameAndStatusOrderByCreatedAtDesc(username, "ACTIVE");
         } else {
             sessions = sessionRepository.findByStatusOrderByCreatedAtDesc("ACTIVE");
         }

--- a/src/test/java/com/zhenduanqi/controller/ArthasSessionControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/ArthasSessionControllerTest.java
@@ -161,7 +161,7 @@ class ArthasSessionControllerTest {
         session2.setId(2L);
         session2.setStatus("ACTIVE");
 
-        when(sessionService.getActiveSessions(anyString())).thenReturn(List.of(session1, session2));
+        when(sessionService.getActiveSessions(eq("server-1"), eq(null))).thenReturn(List.of(session1, session2));
 
         mockMvc.perform(get("/api/arthas-sessions")
                         .cookie(adminCookie)
@@ -171,29 +171,32 @@ class ArthasSessionControllerTest {
     }
 
     @Test
-    void getActiveSessions_withOperatorAuth_returns200() throws Exception {
-        ArthasSessionDTO session = new ArthasSessionDTO();
-        session.setId(1L);
-        session.setStatus("ACTIVE");
+    void getActiveSessions_withAdminAuthAndUsername_returns200() throws Exception {
+        ArthasSessionDTO session1 = new ArthasSessionDTO();
+        session1.setId(1L);
+        session1.setStatus("ACTIVE");
 
-        when(sessionService.getActiveSessions(anyString())).thenReturn(List.of(session));
+        when(sessionService.getActiveSessions(eq(null), eq("user1"))).thenReturn(List.of(session1));
 
         mockMvc.perform(get("/api/arthas-sessions")
-                        .cookie(operatorCookie))
-                .andExpect(status().isOk());
+                        .cookie(adminCookie)
+                        .param("username", "user1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
     }
 
     @Test
-    void getActiveSessions_withReadonlyAuth_returns200() throws Exception {
-        ArthasSessionDTO session = new ArthasSessionDTO();
-        session.setId(1L);
-        session.setStatus("ACTIVE");
+    void getActiveSessions_withOperatorAuth_returns403() throws Exception {
+        mockMvc.perform(get("/api/arthas-sessions")
+                        .cookie(operatorCookie))
+                .andExpect(status().isForbidden());
+    }
 
-        when(sessionService.getActiveSessions(anyString())).thenReturn(List.of(session));
-
+    @Test
+    void getActiveSessions_withReadonlyAuth_returns403() throws Exception {
         mockMvc.perform(get("/api/arthas-sessions")
                         .cookie(readonlyCookie))
-                .andExpect(status().isOk());
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/zhenduanqi/service/ArthasSessionServiceTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasSessionServiceTest.java
@@ -157,7 +157,7 @@ class ArthasSessionServiceTest {
         when(sessionRepository.findByServerIdAndStatusOrderByCreatedAtDesc("server1", "ACTIVE"))
                 .thenReturn(List.of(session1));
 
-        List<ArthasSessionDTO> result = sessionService.getActiveSessions("server1");
+        List<ArthasSessionDTO> result = sessionService.getActiveSessions("server1", null);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(1L);
@@ -178,9 +178,43 @@ class ArthasSessionServiceTest {
         when(sessionRepository.findByStatusOrderByCreatedAtDesc("ACTIVE"))
                 .thenReturn(List.of(session1, session2));
 
-        List<ArthasSessionDTO> result = sessionService.getActiveSessions(null);
+        List<ArthasSessionDTO> result = sessionService.getActiveSessions(null, null);
 
         assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void getActiveSessions_withUsername_returnsFilteredSessions() {
+        ArthasSession session1 = new ArthasSession();
+        session1.setId(1L);
+        session1.setServerId("server1");
+        session1.setUsername("user1");
+        session1.setStatus("ACTIVE");
+
+        when(sessionRepository.findByUsernameAndStatusOrderByCreatedAtDesc("user1", "ACTIVE"))
+                .thenReturn(List.of(session1));
+
+        List<ArthasSessionDTO> result = sessionService.getActiveSessions(null, "user1");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUsername()).isEqualTo("user1");
+    }
+
+    @Test
+    void getActiveSessions_withServerIdAndUsername_returnsFilteredSessions() {
+        ArthasSession session1 = new ArthasSession();
+        session1.setId(1L);
+        session1.setServerId("server1");
+        session1.setUsername("user1");
+        session1.setStatus("ACTIVE");
+
+        when(sessionRepository.findByServerIdAndUsernameAndStatusOrderByCreatedAtDesc("server1", "user1", "ACTIVE"))
+                .thenReturn(List.of(session1));
+
+        List<ArthasSessionDTO> result = sessionService.getActiveSessions("server1", "user1");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUsername()).isEqualTo("user1");
     }
 
     @Test


### PR DESCRIPTION
## 功能概述

实现 US23 活跃会话管理功能，允许管理员查看和管控所有活跃的 Arthas 会话。

## 验收标准完成情况

### Happy Path
- ✅ 管理员可以访问会话管理页面
- ✅ 显示所有活跃会话列表
- ✅ 每个会话显示：服务器、操作人、创建时间、当前命令
- ✅ 可以手动关闭会话
- ✅ 关闭会话时自动执行 reset + close_session

### 边界条件
- ✅ 无活跃会话时显示空状态
- ✅ 会话列表支持按服务器筛选
- ✅ 会话列表支持按操作人筛选

### 异常场景
- ✅ 非管理员用户访问会话管理页面，返回 403
- ✅ 关闭不存在的会话，返回 404
- ✅ 关闭会话失败时显示错误提示

## 实现细节

### 后端改动
1. **权限控制**：在 `ArthasSessionController.getActiveSessions()` 添加 `@RequireRole("ADMIN")` 注解
2. **筛选功能**：支持按 `serverId` 和 `username` 筛选会话
3. **Repository**：新增 `findByServerIdAndUsernameAndStatusOrderByCreatedAtDesc` 方法
4. **Service**：更新 `getActiveSessions` 方法支持多条件组合查询

### 前端改动
1. **权限检查**：页面加载时检查用户角色，非管理员显示权限不足提示
2. **筛选表单**：添加服务器和操作人下拉筛选框
3. **显示优化**：服务器列显示名称而非 ID
4. **错误处理**：完善 403、404 等错误提示

## 测试验证

### 单元测试
- ✅ 18 个单元测试全部通过
- ✅ 覆盖所有权限场景（ADMIN/OPERATOR/READONLY/未认证）
- ✅ 覆盖筛选功能测试

### Playwright E2E 验证

使用 Playwright 进行了完整的端到端验证，所有测试通过：

#### Admin 用户验证
- ✅ 登录成功后可访问会话管理页面
- ✅ 页面正确显示"会话管理"标题
- ✅ 无会话时显示"暂无活跃会话"空状态
- ✅ 筛选表单正确显示（服务器、操作人筛选器、重置按钮）
- ✅ 表格正确渲染
- ✅ 刷新按钮存在

#### 非 Admin 用户验证
- ✅ Operator 用户访问会话管理页面，显示"权限不足"提示
- ✅ Readonly 用户访问会话管理页面，显示"权限不足"提示

#### 验证截图
- 登录页面：`01_login_page.png`
- 登录后主页：`02_after_login.png`
- 会话管理页面（Admin）：`03_session_manage_page.png`
- Operator 权限拒绝：`06_operator_session_page.png`
- Readonly 权限拒绝：`08_readonly_session_page.png`

Closes #135