### PR TITLE
[P2] 场景6验收 - 方法耗时追踪 (#132)

### DIFF
--- a/frontend/src/components/ResultRenderer/TraceRenderer.vue
+++ b/frontend/src/components/ResultRenderer/TraceRenderer.vue
@@ -1,0 +1,135 @@
+<template>
+  <div>
+    <div style="margin-bottom: 8px; font-weight: 500; font-size: 14px">
+      方法调用追踪: {{ className }}.{{ methodName }}
+    </div>
+    <div v-if="timestamp" style="margin-bottom: 8px; font-size: 12px; color: #909399">
+      时间: {{ formatTimestamp(timestamp) }} | 总耗时: {{ totalCost }}ms
+    </div>
+    <div
+      style="
+        background: #f5f7fa;
+        padding: 12px;
+        border-radius: 4px;
+        font-size: 13px;
+        line-height: 1.8;
+        overflow-x: auto;
+        white-space: pre;
+        font-family: monospace;
+      "
+    >
+      {{ formattedTrace }}
+    </div>
+    <div
+      v-if="isExample"
+      style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic"
+    >
+      (示例数据)
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  data: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const defaultData = {
+  className: 'com.example.TestClass',
+  methodName: 'testMethod',
+  cost: 123.45,
+  ts: Date.now(),
+  trace: [
+    {
+      className: 'com.example.TestClass',
+      methodName: 'testMethod',
+      cost: 123.45,
+      depth: 0,
+    },
+    {
+      className: 'com.example.Helper',
+      methodName: 'helperMethod',
+      cost: 45.67,
+      depth: 1,
+    },
+    {
+      className: 'com.example.Helper',
+      methodName: 'anotherMethod',
+      cost: 23.45,
+      depth: 1,
+    },
+  ],
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
+const className = computed(() => {
+  return currentData.value.className || currentData.value.class || '';
+});
+
+const methodName = computed(() => {
+  return currentData.value.methodName || currentData.value.method || '';
+});
+
+const totalCost = computed(() => {
+  const cost = currentData.value.cost || currentData.value.totalCost || 0;
+  return typeof cost === 'number' ? cost.toFixed(2) : cost;
+});
+
+const timestamp = computed(() => {
+  return currentData.value.ts || currentData.value.timestamp;
+});
+
+const formattedTrace = computed(() => {
+  const trace = currentData.value.trace || currentData.value.children || [];
+  if (trace.length === 0) {
+    const rawValue = currentData.value.value || currentData.value.raw || '';
+    if (rawValue) return rawValue;
+    return formatSingleTrace(currentData.value);
+  }
+  return formatTraceTree(trace);
+});
+
+function formatSingleTrace(item) {
+  const cost = item.cost || 0;
+  const cls = item.className || item.class || '';
+  const method = item.methodName || item.method || '';
+  return `---[${cost.toFixed(2)}ms]${cls}:${method}()`;
+}
+
+function formatTraceTree(trace, depth = 0) {
+  let result = '';
+  for (const item of trace) {
+    const indent = '  '.repeat(depth);
+    const prefix = depth === 0 ? '`---' : '+---';
+    const cost = item.cost || 0;
+    const cls = item.className || item.class || '';
+    const method = item.methodName || item.method || '';
+    result += `${indent}${prefix}[${cost.toFixed(2)}ms]${cls}:${method}()\n`;
+    if (item.children && item.children.length > 0) {
+      result += formatTraceTree(item.children, depth + 1);
+    }
+  }
+  return result.trim();
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '-';
+  const date = new Date(ts);
+  return date.toLocaleString();
+}
+</script>

--- a/frontend/src/components/ResultRenderer/WatchRenderer.vue
+++ b/frontend/src/components/ResultRenderer/WatchRenderer.vue
@@ -15,9 +15,7 @@
       <pre class="watch-code-block">{{ formatValue(returnObj) }}</pre>
     </div>
     <div v-if="throwExp" style="margin-bottom: 12px">
-      <div style="font-weight: 500; margin-bottom: 4px; font-size: 13px; color: #f56c6c">
-        异常:
-      </div>
+      <div style="font-weight: 500; margin-bottom: 4px; font-size: 13px; color: #f56c6c">异常:</div>
       <pre class="watch-code-block" style="color: #f56c6c">{{ formatValue(throwExp) }}</pre>
     </div>
     <div v-if="object" style="margin-bottom: 12px">

--- a/frontend/src/components/ResultRenderer/WatchRenderer.vue
+++ b/frontend/src/components/ResultRenderer/WatchRenderer.vue
@@ -1,0 +1,141 @@
+<template>
+  <div>
+    <div style="margin-bottom: 8px; font-weight: 500; font-size: 14px">
+      方法观察: {{ className }}.{{ methodName }}
+    </div>
+    <div v-if="timestamp" style="margin-bottom: 8px; font-size: 12px; color: #909399">
+      时间: {{ formatTimestamp(timestamp) }} | 耗时: {{ cost }}ms | 位置: {{ location }}
+    </div>
+    <div v-if="params" style="margin-bottom: 12px">
+      <div style="font-weight: 500; margin-bottom: 4px; font-size: 13px">入参:</div>
+      <pre class="watch-code-block">{{ formatValue(params) }}</pre>
+    </div>
+    <div v-if="returnObj !== undefined" style="margin-bottom: 12px">
+      <div style="font-weight: 500; margin-bottom: 4px; font-size: 13px">返回值:</div>
+      <pre class="watch-code-block">{{ formatValue(returnObj) }}</pre>
+    </div>
+    <div v-if="throwExp" style="margin-bottom: 12px">
+      <div style="font-weight: 500; margin-bottom: 4px; font-size: 13px; color: #f56c6c">
+        异常:
+      </div>
+      <pre class="watch-code-block" style="color: #f56c6c">{{ formatValue(throwExp) }}</pre>
+    </div>
+    <div v-if="object" style="margin-bottom: 12px">
+      <div style="font-weight: 500; margin-bottom: 4px; font-size: 13px">对象:</div>
+      <pre class="watch-code-block">{{ formatValue(object) }}</pre>
+    </div>
+    <div
+      v-if="isExample"
+      style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic"
+    >
+      (示例数据)
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  data: {
+    type: Object,
+    default: () => ({}),
+  },
+});
+
+const defaultData = {
+  className: 'com.example.TestClass',
+  methodName: 'testMethod',
+  cost: 12.34,
+  ts: Date.now(),
+  location: 'AtExit',
+  params: [
+    { type: 'String', value: 'test-param' },
+    { type: 'Integer', value: 123 },
+  ],
+  returnObj: { type: 'String', value: 'result-value' },
+  throwExp: null,
+};
+
+const currentData = computed(() => {
+  if (!props.data || Object.keys(props.data).length === 0) {
+    return defaultData;
+  }
+  return props.data;
+});
+
+const isExample = computed(() => {
+  return !props.data || Object.keys(props.data).length === 0;
+});
+
+const className = computed(() => {
+  return currentData.value.className || currentData.value.class || '';
+});
+
+const methodName = computed(() => {
+  return currentData.value.methodName || currentData.value.method || '';
+});
+
+const cost = computed(() => {
+  const c = currentData.value.cost || 0;
+  return typeof c === 'number' ? c.toFixed(2) : c;
+});
+
+const timestamp = computed(() => {
+  return currentData.value.ts || currentData.value.timestamp;
+});
+
+const location = computed(() => {
+  return currentData.value.location || 'AtExit';
+});
+
+const params = computed(() => {
+  return currentData.value.params || currentData.value.parameters;
+});
+
+const returnObj = computed(() => {
+  return currentData.value.returnObj || currentData.value.returnValue;
+});
+
+const throwExp = computed(() => {
+  return currentData.value.throwExp || currentData.value.throwException;
+});
+
+const object = computed(() => {
+  return currentData.value.object || currentData.value.target;
+});
+
+function formatValue(value) {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '-';
+  const date = new Date(ts);
+  return date.toLocaleString();
+}
+</script>
+
+<style scoped>
+.watch-code-block {
+  background: #f5f7fa;
+  padding: 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>

--- a/frontend/src/components/ResultRenderer/index.js
+++ b/frontend/src/components/ResultRenderer/index.js
@@ -11,6 +11,8 @@ import ClassloaderRenderer from './ClassloaderRenderer.vue';
 import JadRenderer from './JadRenderer.vue';
 import MonitorRenderer from './MonitorRenderer.vue';
 import StackRenderer from './StackRenderer.vue';
+import TraceRenderer from './TraceRenderer.vue';
+import WatchRenderer from './WatchRenderer.vue';
 
 const rendererMap = {
   thread: ThreadRenderer,
@@ -27,6 +29,8 @@ const rendererMap = {
   jad: JadRenderer,
   monitor: MonitorRenderer,
   stack: StackRenderer,
+  trace: TraceRenderer,
+  watch: WatchRenderer,
 };
 
 export function getRenderer(type) {
@@ -47,4 +51,6 @@ export {
   JadRenderer,
   MonitorRenderer,
   StackRenderer,
+  TraceRenderer,
+  WatchRenderer,
 };


### PR DESCRIPTION
## 概述
为场景6（方法耗时追踪）添加 TraceRenderer 和 WatchRenderer 组件，支持 trace 和 watch 命令结果的渲染。

## 变更内容
- 新增 `TraceRenderer.vue`：渲染 trace 命令的方法调用追踪结果
- 新增 `WatchRenderer.vue`：渲染 watch 命令的方法观察结果
- 更新 `ResultRenderer/index.js`：注册新的渲染器

## 验收测试结果
使用 Playwright 进行验收测试，结果如下：
- ✅ 登录系统
- ✅ 选择场景6
- ✅ 服务器选择
- ✅ 进入诊断页面
- ✅ 步骤1命令（sc -d {className}）
- ✅ 步骤2连续输出标记（trace 命令）
- ✅ 占位符提示
- ✅ 渲染器组件创建

## 截图
测试截图已保存：
- /tmp/scene_list.png - 场景列表页面
- /tmp/scene6_dialog.png - 服务器选择对话框
- /tmp/scene6_diagnosis.png - 诊断页面
- /tmp/scene6_final.png - 最终结果

Closes #132