### PR TITLE
[P0] US12 验收 — 服务器管理 (#109)

### DIFF
--- a/src/main/java/com/zhenduanqi/controller/ArthasServerController.java
+++ b/src/main/java/com/zhenduanqi/controller/ArthasServerController.java
@@ -33,33 +33,45 @@ public class ArthasServerController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @GetMapping("/{id}/status")
-    public ResponseEntity<Map<String, Boolean>> getStatus(@PathVariable String id) {
-        boolean connected = serverService.checkConnection(id);
-        return ResponseEntity.ok(Map.of("connected", connected));
-    }
-
     @PostMapping
     @RequireRole("ADMIN")
     @AuditLog(action = "创建服务器")
-    public ResponseEntity<ArthasServerDTO> create(@RequestBody ArthasServerDTO dto) {
-        ArthasServerDTO created = serverService.create(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    public ResponseEntity<?> create(@RequestBody ArthasServerDTO dto) {
+        try {
+            ArthasServerDTO created = serverService.create(dto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
 
     @PutMapping("/{id}")
     @RequireRole("ADMIN")
     @AuditLog(action = "更新服务器")
-    public ResponseEntity<ArthasServerDTO> update(@PathVariable String id, @RequestBody ArthasServerDTO dto) {
-        ArthasServerDTO updated = serverService.update(id, dto);
-        return ResponseEntity.ok(updated);
+    public ResponseEntity<?> update(@PathVariable String id, @RequestBody ArthasServerDTO dto) {
+        try {
+            ArthasServerDTO updated = serverService.update(id, dto);
+            return ResponseEntity.ok(updated);
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("不存在")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
 
     @DeleteMapping("/{id}")
     @RequireRole("ADMIN")
     @AuditLog(action = "删除服务器")
-    public ResponseEntity<Void> delete(@PathVariable String id) {
-        serverService.delete(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> delete(@PathVariable String id) {
+        try {
+            serverService.delete(id);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("不存在")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/zhenduanqi/controller/ArthasServerController.java
+++ b/src/main/java/com/zhenduanqi/controller/ArthasServerController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/servers")
@@ -30,6 +31,12 @@ public class ArthasServerController {
         return serverService.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/status")
+    public ResponseEntity<Map<String, Boolean>> getStatus(@PathVariable String id) {
+        boolean connected = serverService.checkConnection(id);
+        return ResponseEntity.ok(Map.of("connected", connected));
     }
 
     @PostMapping

--- a/src/main/java/com/zhenduanqi/service/ArthasServerService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasServerService.java
@@ -1,5 +1,6 @@
 package com.zhenduanqi.service;
 
+import com.zhenduanqi.client.ArthasHttpClient;
 import com.zhenduanqi.config.TokenEncryptionUtil;
 import com.zhenduanqi.dto.ArthasServerDTO;
 import com.zhenduanqi.entity.ArthasServerEntity;
@@ -20,10 +21,12 @@ public class ArthasServerService {
 
     private final ArthasServerRepository repository;
     private final TokenEncryptionUtil encryptionUtil;
+    private final ArthasHttpClient arthasHttpClient;
 
-    public ArthasServerService(ArthasServerRepository repository, TokenEncryptionUtil encryptionUtil) {
+    public ArthasServerService(ArthasServerRepository repository, TokenEncryptionUtil encryptionUtil, ArthasHttpClient arthasHttpClient) {
         this.repository = repository;
         this.encryptionUtil = encryptionUtil;
+        this.arthasHttpClient = arthasHttpClient;
     }
 
     public List<ArthasServerDTO> findAll() {
@@ -121,5 +124,13 @@ public class ArthasServerService {
         }
         repository.deleteById(id);
         log.info("服务器删除: id={}", id);
+    }
+
+    public boolean checkConnection(String id) {
+        Optional<ServerInfo> serverInfoOpt = findServerInfoById(id);
+        if (serverInfoOpt.isEmpty()) {
+            return false;
+        }
+        return arthasHttpClient.checkConnection(serverInfoOpt.get());
     }
 }

--- a/src/main/java/com/zhenduanqi/service/ArthasServerService.java
+++ b/src/main/java/com/zhenduanqi/service/ArthasServerService.java
@@ -84,6 +84,10 @@ public class ArthasServerService {
     }
 
     public ArthasServerDTO create(ArthasServerDTO dto) {
+        if (repository.existsById(dto.getId())) {
+            throw new RuntimeException("服务器 ID 已存在: " + dto.getId());
+        }
+        validateServerDTO(dto);
         ArthasServerEntity entity = dto.toEntity();
         if (entity.getToken() != null) {
             entity.setToken(encryptionUtil.encrypt(entity.getToken()));
@@ -97,6 +101,41 @@ public class ArthasServerService {
         ArthasServerEntity saved = repository.save(entity);
         log.info("服务器创建: id={}, name={}", saved.getId(), saved.getName());
         return ArthasServerDTO.fromEntity(saved);
+    }
+
+    private void validateServerDTO(ArthasServerDTO dto) {
+        if (dto.getId() == null || dto.getId().isBlank()) {
+            throw new RuntimeException("服务器 ID 不能为空");
+        }
+        if (!dto.getId().matches("^[a-zA-Z0-9_-]{1,50}$")) {
+            throw new RuntimeException("服务器 ID 格式无效，仅允许字母、数字、下划线、连字符，长度 1-50");
+        }
+        if (dto.getName() == null || dto.getName().isBlank()) {
+            throw new RuntimeException("服务器名称不能为空");
+        }
+        if (dto.getHost() == null || dto.getHost().isBlank()) {
+            throw new RuntimeException("主机地址不能为空");
+        }
+        if (!isValidHost(dto.getHost())) {
+            throw new RuntimeException("主机地址格式无效");
+        }
+        if (dto.getHttpPort() < 1 || dto.getHttpPort() > 65535) {
+            throw new RuntimeException("端口范围必须在 1-65535 之间");
+        }
+    }
+
+    private boolean isValidHost(String host) {
+        if (host.matches("^(\\d{1,3}\\.){3}\\d{1,3}$")) {
+            String[] parts = host.split("\\.");
+            for (String part : parts) {
+                int num = Integer.parseInt(part);
+                if (num < 0 || num > 255) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return host.matches("^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$");
     }
 
     public ArthasServerDTO update(String id, ArthasServerDTO dto) {

--- a/src/test/java/com/zhenduanqi/controller/ArthasServerControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/ArthasServerControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -194,5 +195,57 @@ class ArthasServerControllerTest {
     void deleteServer_withReadonlyAuth_returns403() throws Exception {
         mockMvc.perform(delete("/api/servers/server-1").cookie(readonlyCookie))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createServer_withDuplicateId_returns400() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.102");
+        dto.setHttpPort(8563);
+
+        when(serverService.create(any())).thenThrow(new RuntimeException("服务器 ID 已存在: server-1"));
+
+        mockMvc.perform(post("/api/servers")
+                        .cookie(adminCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("服务器 ID 已存在: server-1"));
+    }
+
+    @Test
+    void updateServer_withNonExistentId_returns404() throws Exception {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setName("更新名称");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(serverService.update(eq("non-existent"), any())).thenThrow(new RuntimeException("服务器不存在: non-existent"));
+
+        mockMvc.perform(put("/api/servers/non-existent")
+                        .cookie(adminCookie)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("服务器不存在: non-existent"));
+    }
+
+    @Test
+    void deleteServer_withNonExistentId_returns404() throws Exception {
+        doThrow(new RuntimeException("服务器不存在: non-existent")).when(serverService).delete("non-existent");
+
+        mockMvc.perform(delete("/api/servers/non-existent").cookie(adminCookie))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("服务器不存在: non-existent"));
+    }
+
+    @Test
+    void getServerById_withNonExistentId_returns404() throws Exception {
+        when(serverService.findById("non-existent")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/servers/non-existent").cookie(adminCookie))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/zhenduanqi/service/ArthasServerServiceLoggingTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasServerServiceLoggingTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.zhenduanqi.client.ArthasHttpClient;
 import com.zhenduanqi.config.TokenEncryptionUtil;
 import com.zhenduanqi.dto.ArthasServerDTO;
 import com.zhenduanqi.repository.ArthasServerRepository;
@@ -29,11 +30,14 @@ class ArthasServerServiceLoggingTest {
     @Mock
     private TokenEncryptionUtil encryptionUtil;
 
+    @Mock
+    private ArthasHttpClient arthasHttpClient;
+
     private ArthasServerService service;
 
     @BeforeEach
     void setUp() {
-        service = new ArthasServerService(repository, encryptionUtil);
+        service = new ArthasServerService(repository, encryptionUtil, arthasHttpClient);
     }
 
     private ListAppender<ILoggingEvent> createListAppender() {

--- a/src/test/java/com/zhenduanqi/service/ArthasServerServiceTest.java
+++ b/src/test/java/com/zhenduanqi/service/ArthasServerServiceTest.java
@@ -1,0 +1,197 @@
+package com.zhenduanqi.service;
+
+import com.zhenduanqi.client.ArthasHttpClient;
+import com.zhenduanqi.config.TokenEncryptionUtil;
+import com.zhenduanqi.dto.ArthasServerDTO;
+import com.zhenduanqi.entity.ArthasServerEntity;
+import com.zhenduanqi.repository.ArthasServerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArthasServerServiceTest {
+
+    @Mock
+    private ArthasServerRepository repository;
+
+    @Mock
+    private TokenEncryptionUtil encryptionUtil;
+
+    @Mock
+    private ArthasHttpClient arthasHttpClient;
+
+    private ArthasServerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ArthasServerService(repository, encryptionUtil, arthasHttpClient);
+    }
+
+    @Test
+    void create_withValidData_succeeds() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server-1")).thenReturn(false);
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        ArthasServerDTO result = service.create(dto);
+        assertThat(result.getId()).isEqualTo("server-1");
+    }
+
+    @Test
+    void create_withDuplicateId_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server-1")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("服务器 ID 已存在");
+    }
+
+    @Test
+    void create_withEmptyId_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("服务器 ID 不能为空");
+    }
+
+    @Test
+    void create_withInvalidIdFormat_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server@1");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server@1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("服务器 ID 格式无效");
+    }
+
+    @Test
+    void create_withEmptyName_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("服务器名称不能为空");
+    }
+
+    @Test
+    void create_withEmptyHost_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("主机地址不能为空");
+    }
+
+    @Test
+    void create_withInvalidHostFormat_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("invalid host!");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("主机地址格式无效");
+    }
+
+    @Test
+    void create_withInvalidPort_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(70000);
+
+        when(repository.existsById("server-1")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.create(dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("端口范围必须在 1-65535 之间");
+    }
+
+    @Test
+    void create_withValidHostname_succeeds() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setId("server-1");
+        dto.setName("测试服务器");
+        dto.setHost("example.com");
+        dto.setHttpPort(8563);
+
+        when(repository.existsById("server-1")).thenReturn(false);
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        ArthasServerDTO result = service.create(dto);
+        assertThat(result.getId()).isEqualTo("server-1");
+    }
+
+    @Test
+    void update_withNonExistentId_throwsException() {
+        ArthasServerDTO dto = new ArthasServerDTO();
+        dto.setName("更新名称");
+        dto.setHost("192.168.1.100");
+        dto.setHttpPort(8563);
+
+        when(repository.findById("non-existent")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update("non-existent", dto))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("服务器不存在");
+    }
+
+    @Test
+    void delete_withNonExistentId_throwsException() {
+        when(repository.existsById("non-existent")).thenReturn(false);
+
+        assertThatThrownBy(() -> service.delete("non-existent"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("服务器不存在");
+    }
+}


### PR DESCRIPTION
## 功能描述

完成 US12 服务器管理的验收标准实现。

## 验收标准

### Happy Path
- [x] 管理员可以查看服务器列表
- [x] 管理员可以新增服务器（ID、名称、主机、端口、认证方式）
- [x] 管理员可以编辑服务器信息
- [x] 管理员可以删除服务器
- [x] 新增服务器时密码/Token 加密存储
- [x] 服务器管理操作有审计日志记录

### 边界条件
- [x] 服务器 ID 不能重复
- [x] 服务器 ID 格式校验（字母、数字、下划线、连字符，长度 1-50）
- [x] 主机名/IP 格式校验
- [x] 端口范围校验（1-65535）
- [x] 默认端口 8563
- [x] 默认用户名 arthas

### 异常场景
- [x] 非管理员用户尝试管理服务器，返回 403
- [x] 创建服务器时 ID 已存在，返回 400 错误提示
- [x] 编辑不存在的服务器，返回 404
- [x] 删除不存在的服务器，返回 404

## 验证情况

### 单元测试
- Controller 层测试：新增 ID 重复、服务器不存在等异常场景测试
- Service 层测试：新增完整的验证逻辑测试

### Playwright 验证
- 登录页面加载正常
- Admin 登录成功
- 服务器列表页面可访问
- 添加服务器对话框正常工作
- 编辑服务器对话框正常工作

## 技术变更

- `ArthasServerService`: 添加 ID 重复检查、格式验证、端口范围验证
- `ArthasServerController`: 添加异常处理，返回正确的 HTTP 状态码
- 移除重复的 `/api/servers/{id}/status` 端点（与 ArthasExecuteController 冲突）

Closes #109