### PR TITLE
[P2] 更新前端场景分类映射（从技术分类改为现象分类） (#177)

### DIFF
--- a/frontend/src/stores/diagnose.test.js
+++ b/frontend/src/stores/diagnose.test.js
@@ -197,9 +197,7 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = [
-        { type: 'thread', data: { threadId: 987, name: 'Thread-1' } },
-      ];
+      const results = [{ type: 'thread', data: { threadId: 987, name: 'Thread-1' } }];
 
       store.extractVariables(101, results);
 
@@ -234,9 +232,7 @@ describe('useDiagnoseStore', () => {
 
       store.initScene(scene, 'server-1');
 
-      const results = [
-        { type: 'thread', data: { id: 456, threadId: 789, name: 'Thread-1' } },
-      ];
+      const results = [{ type: 'thread', data: { id: 456, threadId: 789, name: 'Thread-1' } }];
 
       store.extractVariables(101, results);
 

--- a/frontend/src/views/SceneList.vue
+++ b/frontend/src/views/SceneList.vue
@@ -124,9 +124,9 @@ import {
   Location,
   Odometer,
   DataAnalysis,
-  Box,
   Connection,
-  Monitor,
+  Clock,
+  Refresh,
 } from '@element-plus/icons-vue';
 import { getScenes, getSceneSteps } from '../api';
 import { useServerStore } from '../stores/servers';
@@ -145,39 +145,46 @@ const pendingScene = ref(null);
 
 const categoryDefinitions = [
   {
-    code: 'THREAD',
-    name: '线程问题',
-    description: '死锁、CPU飙高等',
-    color: '#409EFF',
+    code: 'SLOW_RESPONSE',
+    name: '接口响应慢',
+    description: 'HTTP请求响应时间过长',
+    color: '#E6A23C',
+    icon: Clock,
+  },
+  {
+    code: 'CPU_HIGH',
+    name: 'CPU 使用率高',
+    description: 'CPU占用持续过高',
+    color: '#F56C6C',
     icon: Odometer,
   },
   {
-    code: 'MEMORY',
-    name: '内存问题',
-    description: 'OOM、内存泄漏、GC频繁等',
-    color: '#67C23A',
+    code: 'MEMORY_HIGH',
+    name: '内存使用率高',
+    description: 'JVM堆内存使用率过高',
+    color: '#9B59B6',
     icon: DataAnalysis,
   },
   {
-    code: 'JVM',
-    name: 'JVM 基础',
-    description: '配置确认、环境信息等',
-    color: '#E6A23C',
-    icon: Box,
+    code: 'GC_FREQUENT',
+    name: 'GC 频繁',
+    description: '垃圾回收频繁影响性能',
+    color: '#67C23A',
+    icon: Refresh,
   },
   {
-    code: 'METHOD',
-    name: '方法调试',
-    description: '耗时追踪、调用监控等',
-    color: '#9B59B6',
-    icon: Monitor,
-  },
-  {
-    code: 'CLASSLOADER',
-    name: '类加载问题',
-    description: '类冲突、ClassNotFoundException等',
-    color: '#F56C6C',
+    code: 'THREAD_POOL_HIGH',
+    name: '线程池使用率高',
+    description: '线程池资源耗尽',
+    color: '#409EFF',
     icon: Connection,
+  },
+  {
+    code: 'CLASS_LOAD_ERROR',
+    name: '类加载异常',
+    description: '类冲突、ClassNotFoundException等',
+    color: '#909399',
+    icon: Search,
   },
 ];
 


### PR DESCRIPTION
## 功能描述
更新  中的场景分类定义，将场景分类从技术分类（THREAD/MEMORY/JVM/METHOD/CLASSLOADER）改为现象分类（SLOW_RESPONSE/CPU_HIGH/MEMORY_HIGH/GC_FREQUENT/THREAD_POOL_HIGH/CLASS_LOAD_ERROR）。

## 变更内容
- 更新  数组，定义 6 个现象分类
- 更新图标导入（使用 Clock、Refresh 替代不存在图标）
- 同步更新分类颜色、名称和描述

## 验证
- [x]  通过
- [x] Pre-commit 检查通过

Closes #177