### PR TITLE
[P2] feat(diagnose): 执行诊断页面改进（智能命令输入 + 帮助面板） (#185)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 target/
 frontend/node_modules/
 frontend/dist/
-data/
+/data/
 *.log
 .DS_Store
 Thumbs.db

--- a/PRD.md
+++ b/PRD.md
@@ -1035,7 +1035,10 @@ zhenduanqi/
 │       │   ├── servers.js           # 服务器 Pinia store
 │       │   ├── user.js              # 当前用户 store (登录/角色/权限)
 │       │   ├── scene.js             # 场景 store
-│       │   └── diagnose.js          # 诊断会话 store（步骤状态、变量缓存）
+│       │   ├── diagnose.js          # 诊断会话 store（步骤状态、变量缓存）
+│       │   └── commandCache.js      # 命令历史缓存 store
+│       ├── data/
+│       │   └── arthas-commands.json # Arthas 命令清单数据（46个常用命令）
 │       └── views/
 │           ├── Login.vue            # 登录页面
 │           ├── SceneList.vue        # 场景列表页（按分类卡片展示）

--- a/frontend/e2e/diagnose-command-input.spec.py
+++ b/frontend/e2e/diagnose-command-input.spec.py
@@ -1,0 +1,116 @@
+from playwright.sync_api import sync_playwright
+import time
+
+def test_diagnose_page():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context()
+        page = context.new_page()
+        
+        page.goto('http://localhost:5185')
+        page.wait_for_load_state('networkidle')
+        time.sleep(1)
+        
+        page.screenshot(path='/tmp/diagnose-01-login.png', full_page=True)
+        
+        page.fill('input[type="text"]', 'admin')
+        page.fill('input[type="password"]', 'admin123')
+        page.click('button:has-text("登录")')
+        
+        page.wait_for_load_state('networkidle')
+        time.sleep(1)
+        
+        page.goto('http://localhost:5185/#/diagnose')
+        page.wait_for_load_state('networkidle')
+        time.sleep(1)
+        
+        page.screenshot(path='/tmp/diagnose-02-page.png', full_page=True)
+        
+        server_select = page.locator('.el-select').first
+        server_select.click()
+        time.sleep(0.5)
+        
+        page.screenshot(path='/tmp/diagnose-03-server-dropdown.png', full_page=True)
+        
+        options = page.locator('.el-select-dropdown__item')
+        if options.count() > 0:
+            options.first.click()
+            time.sleep(0.5)
+            
+            saved_server = page.evaluate('localStorage.getItem("zhenduanqi_selected_server")')
+            print(f'Server saved to localStorage: {saved_server}')
+            assert saved_server, 'Server should be saved to localStorage'
+        
+        page.screenshot(path='/tmp/diagnose-04-server-selected.png', full_page=True)
+        
+        command_input = page.locator('.el-autocomplete input').first
+        command_input.click()
+        command_input.fill('th')
+        time.sleep(0.5)
+        
+        page.screenshot(path='/tmp/diagnose-05-command-suggestions.png', full_page=True)
+        
+        suggestions = page.locator('.el-autocomplete-suggestion li')
+        suggestion_count = suggestions.count()
+        print(f'Found {suggestion_count} command suggestions')
+        
+        if suggestion_count > 0:
+            thread_suggestion = suggestions.filter(has_text='thread')
+            if thread_suggestion.count() > 0:
+                thread_suggestion.first.click()
+                time.sleep(0.5)
+                
+                command_value = command_input.input_value()
+                print(f'Selected command: {command_value}')
+                assert 'thread' in command_value.lower(), 'Should have selected thread command'
+        
+        page.screenshot(path='/tmp/diagnose-06-command-selected.png', full_page=True)
+        
+        param_input = page.locator('.command-input-wrapper .el-input').last.locator('input')
+        param_input.fill('-n 5')
+        time.sleep(0.3)
+        
+        page.screenshot(path='/tmp/diagnose-07-params-filled.png', full_page=True)
+        
+        preview = page.locator('.preview-code')
+        preview_text = preview.text_content()
+        print(f'Command preview: {preview_text}')
+        assert 'thread' in preview_text.lower(), 'Preview should contain thread'
+        assert '-n 5' in preview_text, 'Preview should contain -n 5'
+        
+        copy_button = page.locator('button:has-text("复制")')
+        if copy_button.count() > 0:
+            print('Copy button found')
+        
+        help_panel = page.locator('.right-panel')
+        assert help_panel.count() > 0, 'Help panel should exist'
+        
+        page.screenshot(path='/tmp/diagnose-08-help-panel.png', full_page=True)
+        
+        collapse_button = help_panel.locator('button')
+        collapse_button.click()
+        time.sleep(0.3)
+        
+        page.screenshot(path='/tmp/diagnose-09-help-collapsed.png', full_page=True)
+        
+        collapse_button.click()
+        time.sleep(0.3)
+        
+        command_list = page.locator('.command-item')
+        command_count = command_list.count()
+        print(f'Found {command_count} commands in help panel')
+        assert command_count > 40, f'Should have at least 40 commands, found {command_count}'
+        
+        page.screenshot(path='/tmp/diagnose-10-final.png', full_page=True)
+        
+        print('\n=== Test Results ===')
+        print('✓ Server selection cache works')
+        print('✓ Command autocomplete works')
+        print('✓ Command preview updates correctly')
+        print('✓ Help panel displays and collapses')
+        print(f'✓ Command list contains {command_count} commands')
+        
+        browser.close()
+
+if __name__ == '__main__':
+    test_diagnose_page()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -33,7 +33,7 @@
         </el-menu-item>
         <el-menu-item
           index="/sessions"
-          v-if="userStore.role === 'ADMIN' || userStore.role === 'OPERATOR'"
+          v-if="userStore.role === 'ADMIN'"
           style="color: white"
         >
           会话管理

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -31,11 +31,7 @@
         <el-menu-item index="/command-guard" v-if="userStore.role === 'ADMIN'" style="color: white">
           命令守卫
         </el-menu-item>
-        <el-menu-item
-          index="/sessions"
-          v-if="userStore.role === 'ADMIN'"
-          style="color: white"
-        >
+        <el-menu-item index="/sessions" v-if="userStore.role === 'ADMIN'" style="color: white">
           会话管理
         </el-menu-item>
       </el-menu>

--- a/frontend/src/data/arthas-commands.json
+++ b/frontend/src/data/arthas-commands.json
@@ -1,0 +1,307 @@
+[
+  {
+    "name": "dashboard",
+    "description": "显示当前系统的实时数据面板，包括内存、CPU、线程信息",
+    "params": "无参数",
+    "examples": ["dashboard"]
+  },
+  {
+    "name": "thread",
+    "description": "查看当前 JVM 的线程堆栈信息",
+    "params": "-n [数量] 显示最忙的N个线程\n-i [毫秒] 指定采样间隔\n--state [状态] 按线程状态过滤\n[id] 查看指定线程的堆栈",
+    "examples": [
+      "thread",
+      "thread -n 5",
+      "thread -n 3 -i 1000",
+      "thread 1",
+      "thread --state BLOCKED"
+    ]
+  },
+  {
+    "name": "jvm",
+    "description": "查看当前 JVM 的基本信息",
+    "params": "无参数",
+    "examples": ["jvm"]
+  },
+  {
+    "name": "sysprop",
+    "description": "查看和修改 JVM 的系统属性",
+    "params": "[属性名] 查看指定属性\n[属性名] [值] 设置属性值",
+    "examples": ["sysprop", "sysprop user.home", "sysprop user.home /tmp"]
+  },
+  {
+    "name": "sysenv",
+    "description": "查看 JVM 的环境变量",
+    "params": "[变量名] 查看指定环境变量",
+    "examples": ["sysenv", "sysenv PATH"]
+  },
+  {
+    "name": "vmoption",
+    "description": "查看和修改 JVM 的诊断选项",
+    "params": "[选项名] 查看指定选项\n[选项名] [值] 设置选项值",
+    "examples": ["vmoption", "vmoption PrintGC", "vmoption PrintGC true"]
+  },
+  {
+    "name": "perfcounter",
+    "description": "查看 JVM 的性能计数器信息",
+    "params": "无参数",
+    "examples": ["perfcounter"]
+  },
+  {
+    "name": "getstatic",
+    "description": "查看类的静态属性",
+    "params": "[类名] [属性名]",
+    "examples": ["getstatic com.example.MyClass FIELD_NAME"]
+  },
+  {
+    "name": "ognl",
+    "description": "执行 OGNL 表达式",
+    "params": "[表达式] OGNL 表达式\n-c [类加载器hash] 指定类加载器\n-x [深度] 指定对象展开深度",
+    "examples": [
+      "ognl @com.example.MyClass@FIELD",
+      "ognl '@System@out.println(\"hello\")'",
+      "ognl -x 2 @com.example.MyClass@instance"
+    ]
+  },
+  {
+    "name": "sc",
+    "description": "查看已加载的类信息",
+    "params": "-d 显示类详情\n-E 使用正则匹配\n-f 显示类成员\n[classPattern] 类名模式",
+    "examples": ["sc com.example.*", "sc -d com.example.MyClass", "sc -f com.example.MyClass"]
+  },
+  {
+    "name": "sm",
+    "description": "查看已加载类的方法信息",
+    "params": "-d 显示方法详情\n-E 使用正则匹配\n[classPattern] [methodPattern]",
+    "examples": [
+      "sm com.example.MyClass",
+      "sm -d com.example.MyClass methodName",
+      "sm com.example.* method*"
+    ]
+  },
+  {
+    "name": "jad",
+    "description": "反编译已加载类的源码",
+    "params": "[类名] 反编译整个类\n[类名] [方法名] 反编译指定方法\n--source-only 只显示源码",
+    "examples": [
+      "jad com.example.MyClass",
+      "jad com.example.MyClass methodName",
+      "jad --source-only com.example.MyClass"
+    ]
+  },
+  {
+    "name": "mc",
+    "description": "内存编译器，编译 Java 源码",
+    "params": "-d [目录] 指定输出目录\n[源码文件或目录]",
+    "examples": ["mc /tmp/Test.java", "mc -d /tmp/output /tmp/Test.java"]
+  },
+  {
+    "name": "retransform",
+    "description": "重新加载外部的 .class 文件",
+    "params": "[class文件路径]",
+    "examples": ["retransform /tmp/Test.class"]
+  },
+  {
+    "name": "dump",
+    "description": "dump 已加载类的字节码到文件",
+    "params": "-d [目录] 指定输出目录\n[classPattern] 类名模式",
+    "examples": ["dump com.example.MyClass", "dump -d /tmp com.example.*"]
+  },
+  {
+    "name": "classloader",
+    "description": "查看类加载器的继承结构",
+    "params": "-t 显示类加载器树\n-l 按类加载器实例统计\n-c [hash] 查看指定类加载器加载的类",
+    "examples": ["classloader", "classloader -t", "classloader -l", "classloader -c 3d4eac69"]
+  },
+  {
+    "name": "monitor",
+    "description": "监控方法的执行统计",
+    "params": "-c [秒] 统计周期\n-b 在方法调用前后打印耗时\n[classPattern] [methodPattern]",
+    "examples": ["monitor -c 5 com.example.MyClass methodName", "monitor -b com.example.MyClass *"]
+  },
+  {
+    "name": "stack",
+    "description": "输出方法被调用的调用路径",
+    "params": "-n [次数] 限制输出次数\n[classPattern] [methodPattern] [condition]",
+    "examples": [
+      "stack com.example.MyClass methodName",
+      "stack -n 2 com.example.MyClass methodName"
+    ]
+  },
+  {
+    "name": "trace",
+    "description": "追踪方法内部调用路径和耗时",
+    "params": "-n [次数] 限制输出次数\n#cost [毫秒] 按耗时过滤\n[classPattern] [methodPattern]",
+    "examples": [
+      "trace com.example.MyClass methodName",
+      "trace -n 3 com.example.MyClass methodName",
+      "trace com.example.MyClass methodName '#cost > 100'"
+    ]
+  },
+  {
+    "name": "tt",
+    "description": "时间隧道，记录方法调用的入参和返回值",
+    "params": "-t 记录方法调用\n-l 列出记录\n-i [index] 查看指定记录\n-p 重放调用\n-d 删除记录",
+    "examples": ["tt -t com.example.MyClass methodName", "tt -l", "tt -i 1000 -p", "tt -d -i 1000"]
+  },
+  {
+    "name": "watch",
+    "description": "观察方法的入参、返回值、异常",
+    "params": "-b 在方法调用前观察\n-s 在方法返回后观察\n-e 在方法异常后观察\n-x [深度] 对象展开深度\n[classPattern] [methodPattern] [expression]",
+    "examples": [
+      "watch com.example.MyClass methodName '{params, returnObj}'",
+      "watch -b com.example.MyClass methodName params",
+      "watch -e com.example.MyClass methodName '{params, throwExp}'"
+    ]
+  },
+  {
+    "name": "heapdump",
+    "description": "dump Java 堆到文件",
+    "params": "[文件路径] 输出文件路径\n--live 只 dump 存活对象",
+    "examples": ["heapdump /tmp/dump.hprof", "heapdump --live /tmp/live.hprof"]
+  },
+  {
+    "name": "memory",
+    "description": "查看 JVM 内存信息",
+    "params": "无参数",
+    "examples": ["memory"]
+  },
+  {
+    "name": "vmtool",
+    "description": "JVMTI 工具，可以获取内存中的对象",
+    "params": "--action getInstances 获取对象实例\n--action forceGc 强制GC\n--className [类名]",
+    "examples": [
+      "vmtool --action getInstances --className com.example.MyClass",
+      "vmtool --action forceGc"
+    ]
+  },
+  {
+    "name": "profiler",
+    "description": "使用 async-profiler 进行性能分析",
+    "params": "start 开始采样\nstop 停止采样并输出\n--event [事件] 采样事件(cpu/alloc/lock)\n--duration [秒] 采样时长\n--file [路径] 输出文件",
+    "examples": [
+      "profiler start",
+      "profiler stop",
+      "profiler start --event alloc",
+      "profiler --duration 30 --file /tmp/flamegraph.html start"
+    ]
+  },
+  {
+    "name": "mbean",
+    "description": "查看 MBean 的属性和方法",
+    "params": "[MBean名称] 查看指定MBean\n[name] [attribute] 查看属性",
+    "examples": [
+      "mbean",
+      "mbean java.lang:type=Memory",
+      "mbean java.lang:type=Memory HeapMemoryUsage"
+    ]
+  },
+  {
+    "name": "options",
+    "description": "查看和设置 Arthas 全局选项",
+    "params": "[选项名] 查看选项\n[选项名] [值] 设置选项",
+    "examples": ["options", "options unsafe true", "options json-format true"]
+  },
+  {
+    "name": "logger",
+    "description": "查看和修改 logger 配置",
+    "params": "-n [logger名] 指定logger\n-l [level] 设置日志级别\n--name [logger名]",
+    "examples": ["logger", "logger --name ROOT -l DEBUG", "logger -n com.example -l INFO"]
+  },
+  {
+    "name": "grep",
+    "description": "管道过滤命令输出",
+    "params": "-n 显示行号\n-i 忽略大小写\n-v 反向匹配\n-E 使用正则表达式",
+    "examples": ["thread | grep BLOCKED", "sc com.example.* | grep -i service"]
+  },
+  {
+    "name": "cat",
+    "description": "查看文件内容",
+    "params": "[文件路径]",
+    "examples": ["cat /tmp/test.log"]
+  },
+  {
+    "name": "pwd",
+    "description": "显示当前工作目录",
+    "params": "无参数",
+    "examples": ["pwd"]
+  },
+  {
+    "name": "cls",
+    "description": "清空屏幕",
+    "params": "无参数",
+    "examples": ["cls"]
+  },
+  {
+    "name": "echo",
+    "description": "输出文本",
+    "params": "[文本]",
+    "examples": ["echo hello", "echo $USER"]
+  },
+  {
+    "name": "reset",
+    "description": "重置增强的类",
+    "params": "[类名] 重置指定类\n-E 使用正则匹配",
+    "examples": ["reset", "reset com.example.MyClass", "reset -E com.example.*"]
+  },
+  {
+    "name": "session",
+    "description": "查看当前会话信息",
+    "params": "无参数",
+    "examples": ["session"]
+  },
+  {
+    "name": "version",
+    "description": "查看 Arthas 版本信息",
+    "params": "无参数",
+    "examples": ["version"]
+  },
+  {
+    "name": "quit",
+    "description": "退出 Arthas 客户端",
+    "params": "无参数",
+    "examples": ["quit"]
+  },
+  {
+    "name": "stop",
+    "description": "停止 Arthas 服务端",
+    "params": "无参数",
+    "examples": ["stop"]
+  },
+  {
+    "name": "help",
+    "description": "查看命令帮助",
+    "params": "[命令名] 查看指定命令帮助",
+    "examples": ["help", "help thread"]
+  },
+  {
+    "name": "keymap",
+    "description": "查看和设置快捷键映射",
+    "params": "[快捷键] [命令]",
+    "examples": ["keymap"]
+  },
+  {
+    "name": "history",
+    "description": "查看命令历史",
+    "params": "-c 清空历史\n[n] 显示最近n条",
+    "examples": ["history", "history 10", "history -c"]
+  },
+  {
+    "name": "ttreplay",
+    "description": "重放 tt 命令记录的方法调用",
+    "params": "-i [index] 指定记录索引",
+    "examples": ["ttreplay -i 1000"]
+  },
+  {
+    "name": "ttwatch",
+    "description": "观察 tt 记录",
+    "params": "-i [index] 指定记录索引\n-w [表达式] 观察表达式",
+    "examples": ["ttwatch -i 1000 -w 'target.method(params)'"]
+  },
+  {
+    "name": "heap",
+    "description": "查看堆内存中的对象信息",
+    "params": "--class [类名] 查看指定类的对象",
+    "examples": ["heap --class com.example.MyClass"]
+  }
+]

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHashHistory } from 'vue-router';
+import { ElMessage } from 'element-plus';
 
 const routes = [
   {
@@ -20,7 +21,7 @@ const routes = [
     path: '/scenes/manage',
     name: 'SceneManage',
     component: () => import('../views/SceneManage.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresRole: 'ADMIN' },
   },
   {
     path: '/diagnose',
@@ -32,31 +33,31 @@ const routes = [
     path: '/servers',
     name: 'ServerList',
     component: () => import('../views/ServerList.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresRole: 'ADMIN' },
   },
   {
     path: '/users',
     name: 'UserManage',
     component: () => import('../views/UserManage.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresRole: 'ADMIN' },
   },
   {
     path: '/audit-logs',
     name: 'AuditLog',
     component: () => import('../views/AuditLog.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresRole: 'ADMIN' },
   },
   {
     path: '/command-guard',
     name: 'CommandGuard',
     component: () => import('../views/CommandGuard.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresRole: 'ADMIN' },
   },
   {
     path: '/sessions',
     name: 'SessionManage',
     component: () => import('../views/SessionManage.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresRole: 'ADMIN' },
   },
   {
     path: '/my-history',
@@ -95,6 +96,9 @@ router.beforeEach(async (to, from, next) => {
 
   if (!userStore.isLoggedIn) {
     next('/login');
+  } else if (to.meta.requiresRole && userStore.role !== to.meta.requiresRole) {
+    ElMessage.error('权限不足，无权访问此页面');
+    next('/scenes');
   } else {
     next();
   }

--- a/frontend/src/stores/commandCache.js
+++ b/frontend/src/stores/commandCache.js
@@ -1,0 +1,116 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+const STORAGE_KEY = 'zhenduanqi_command_cache';
+const MAX_HISTORY_SIZE = 100;
+
+export const useCommandCacheStore = defineStore('commandCache', () => {
+  const commandHistory = ref([]);
+  const paramHistory = ref({});
+
+  function loadFromStorage() {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const data = JSON.parse(saved);
+        commandHistory.value = data.commandHistory || [];
+        paramHistory.value = data.paramHistory || {};
+      }
+    } catch (e) {
+      console.warn('Failed to load command cache from storage:', e);
+    }
+  }
+
+  function saveToStorage() {
+    try {
+      const data = {
+        commandHistory: commandHistory.value,
+        paramHistory: paramHistory.value,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {
+      console.warn('Failed to save command cache to storage:', e);
+    }
+  }
+
+  function addCommandToHistory(command) {
+    if (!command || typeof command !== 'string') return;
+
+    const trimmedCommand = command.trim();
+    if (!trimmedCommand) return;
+
+    const parts = trimmedCommand.split(/\s+/);
+    const cmdName = parts[0];
+
+    const existingIndex = commandHistory.value.indexOf(cmdName);
+    if (existingIndex !== -1) {
+      commandHistory.value.splice(existingIndex, 1);
+    }
+
+    commandHistory.value.unshift(cmdName);
+
+    if (commandHistory.value.length > MAX_HISTORY_SIZE) {
+      commandHistory.value = commandHistory.value.slice(0, MAX_HISTORY_SIZE);
+    }
+
+    saveToStorage();
+  }
+
+  function addParamToHistory(command, param) {
+    if (!command || !param) return;
+
+    const trimmedParam = param.trim();
+    if (!trimmedParam) return;
+
+    if (!paramHistory.value[command]) {
+      paramHistory.value[command] = [];
+    }
+
+    const existingIndex = paramHistory.value[command].indexOf(trimmedParam);
+    if (existingIndex !== -1) {
+      paramHistory.value[command].splice(existingIndex, 1);
+    }
+
+    paramHistory.value[command].unshift(trimmedParam);
+
+    if (paramHistory.value[command].length > MAX_HISTORY_SIZE) {
+      paramHistory.value[command] = paramHistory.value[command].slice(0, MAX_HISTORY_SIZE);
+    }
+
+    saveToStorage();
+  }
+
+  function getCommandHistory() {
+    return [...commandHistory.value];
+  }
+
+  function getParamHistory(command) {
+    return paramHistory.value[command] ? [...paramHistory.value[command]] : [];
+  }
+
+  function getLatestParam(command) {
+    const history = paramHistory.value[command];
+    return history && history.length > 0 ? history[0] : '';
+  }
+
+  function clearHistory() {
+    commandHistory.value = [];
+    paramHistory.value = {};
+    saveToStorage();
+  }
+
+  loadFromStorage();
+
+  return {
+    commandHistory,
+    paramHistory,
+    addCommandToHistory,
+    addParamToHistory,
+    getCommandHistory,
+    getParamHistory,
+    getLatestParam,
+    clearHistory,
+    loadFromStorage,
+    saveToStorage,
+  };
+});

--- a/frontend/src/views/Diagnose.vue
+++ b/frontend/src/views/Diagnose.vue
@@ -1,137 +1,417 @@
 <template>
-  <div>
-    <h3>执行诊断命令</h3>
+  <div class="diagnose-page">
+    <div class="main-content">
+      <div class="left-panel">
+        <el-card class="command-card">
+          <template #header>
+            <div class="card-header">
+              <span>执行诊断命令</span>
+            </div>
+          </template>
 
-    <el-card style="margin-bottom: 16px">
-      <el-form :model="form" label-width="100px">
-        <el-form-item label="目标服务器">
-          <el-select v-model="form.serverId" placeholder="请选择服务器" style="width: 300px">
-            <el-option
-              v-for="s in store.list"
-              :key="s.id"
-              :label="s.name + ' (' + s.host + ':' + s.httpPort + ')'"
-              :value="s.id"
-            />
-          </el-select>
-        </el-form-item>
+          <el-form :model="form" label-width="100px">
+            <el-form-item label="目标服务器">
+              <el-select
+                v-model="form.serverId"
+                placeholder="请选择服务器"
+                style="width: 100%"
+                @change="handleServerChange"
+              >
+                <el-option
+                  v-for="s in serverStore.list"
+                  :key="s.id"
+                  :label="s.name + ' (' + s.host + ':' + s.httpPort + ')'"
+                  :value="s.id"
+                />
+              </el-select>
+            </el-form-item>
 
-        <el-form-item label="诊断命令">
-          <el-input
-            v-model="form.command"
-            type="textarea"
-            :rows="4"
-            placeholder="输入 Arthas 命令，例如：&#10;dashboard&#10;thread -n 5&#10;jstack&#10;sc -d com.example.MyController"
-          />
-        </el-form-item>
+            <el-form-item label="诊断命令">
+              <div class="command-input-wrapper">
+                <el-autocomplete
+                  ref="commandInputRef"
+                  v-model="form.command"
+                  :fetch-suggestions="filterCommands"
+                  placeholder="输入或选择命令"
+                  style="width: 200px"
+                  clearable
+                  @select="handleCommandSelect"
+                  @focus="activeInput = 'command'"
+                  @keydown.up.prevent="navigateCommandHistory(-1)"
+                  @keydown.down.prevent="navigateCommandHistory(1)"
+                  @keydown.enter="handleCommandEnter"
+                >
+                  <template #default="{ item }">
+                    <div class="command-suggestion">
+                      <span class="cmd-name">{{ item.name }}</span>
+                      <span class="cmd-desc">{{ item.description }}</span>
+                    </div>
+                  </template>
+                </el-autocomplete>
+                <el-input
+                  ref="paramInputRef"
+                  v-model="form.params"
+                  placeholder="参数（可选）"
+                  style="flex: 1; margin-left: 8px"
+                  clearable
+                  @focus="activeInput = 'params'"
+                  @keydown.up.prevent="navigateParamHistory(-1)"
+                  @keydown.down.prevent="navigateParamHistory(1)"
+                />
+              </div>
+            </el-form-item>
 
-        <el-form-item>
-          <el-button
-            v-if="userStore.role === 'OPERATOR' || userStore.role === 'ADMIN'"
-            type="primary"
-            @click="handleExecute"
-            :loading="executing"
-            :disabled="!form.serverId || !form.command.trim()"
+            <el-form-item label="指令预览">
+              <div class="command-preview">
+                <pre class="preview-code">{{ previewCommand || '（请输入命令）' }}</pre>
+                <el-button
+                  v-if="previewCommand"
+                  size="small"
+                  type="primary"
+                  link
+                  @click="copyCommand"
+                >
+                  <el-icon><CopyDocument /></el-icon>
+                  复制
+                </el-button>
+              </div>
+            </el-form-item>
+
+            <el-form-item>
+              <el-button
+                v-if="userStore.role === 'OPERATOR' || userStore.role === 'ADMIN'"
+                type="primary"
+                @click="handleExecute"
+                :loading="executing"
+                :disabled="!form.serverId || !form.command.trim()"
+              >
+                执行
+              </el-button>
+              <el-button @click="clearResult">清空结果</el-button>
+            </el-form-item>
+          </el-form>
+        </el-card>
+
+        <el-card
+          v-if="result"
+          class="result-card"
+          :style="{ borderLeft: isSuccess ? '4px solid #67c23a' : '4px solid #f56c6c' }"
+        >
+          <template #header>
+            <div style="display: flex; justify-content: space-between; align-items: center">
+              <span>
+                执行结果
+                <el-tag
+                  v-if="result.state === 'succeeded'"
+                  type="success"
+                  size="small"
+                  style="margin-left: 8px"
+                >
+                  成功
+                </el-tag>
+                <el-tag v-else type="danger" size="small" style="margin-left: 8px">失败</el-tag>
+              </span>
+              <el-button size="small" @click="expandRaw = !expandRaw">
+                {{ expandRaw ? '收起原始响应' : '查看原始响应' }}
+              </el-button>
+            </div>
+          </template>
+
+          <div
+            v-if="result.error"
+            style="color: #f56c6c; margin-bottom: 12px; white-space: pre-wrap"
           >
-            执行
-          </el-button>
-          <el-button @click="clearResult">清空结果</el-button>
-        </el-form-item>
-      </el-form>
-    </el-card>
+            {{ result.error }}
+          </div>
 
-    <el-card
-      v-if="result"
-      :style="{ borderLeft: isSuccess ? '4px solid #67c23a' : '4px solid #f56c6c' }"
-    >
-      <template #header>
-        <div style="display: flex; justify-content: space-between; align-items: center">
-          <span>
-            执行结果
-            <el-tag
-              v-if="result.state === 'succeeded'"
-              type="success"
-              size="small"
-              style="margin-left: 8px"
+          <div v-for="(r, i) in result.structuredResults" :key="i">
+            <component :is="getRenderer(r.type)" :data="r.data" />
+          </div>
+
+          <div
+            v-if="result.results && result.results.length > 0 && !result.structuredResults"
+            v-for="(r, i) in result.results"
+            :key="'raw-' + i"
+          >
+            <pre
+              style="
+                background: #f5f7fa;
+                padding: 12px;
+                border-radius: 4px;
+                font-size: 13px;
+                line-height: 1.6;
+                overflow-x: auto;
+              "
+              >{{ r }}</pre
             >
-              成功
-            </el-tag>
-            <el-tag v-else type="danger" size="small" style="margin-left: 8px">失败</el-tag>
-          </span>
-          <el-button size="small" @click="expandRaw = !expandRaw">
-            {{ expandRaw ? '收起原始响应' : '查看原始响应' }}
-          </el-button>
+          </div>
+
+          <div v-if="result.rawResponse && expandRaw" style="margin-top: 12px">
+            <div style="font-weight: 500; margin-bottom: 8px; color: #606266">原始响应</div>
+            <pre
+              style="
+                background: #f5f7fa;
+                padding: 12px;
+                border-radius: 4px;
+                font-size: 12px;
+                max-height: 300px;
+                overflow: auto;
+              "
+              >{{ result.rawResponse }}</pre
+            >
+          </div>
+        </el-card>
+      </div>
+
+      <div class="right-panel" :class="{ collapsed: helpPanelCollapsed }">
+        <div class="help-panel-header">
+          <span v-if="!helpPanelCollapsed">帮助</span>
+          <el-button
+            size="small"
+            :icon="helpPanelCollapsed ? ArrowLeft : ArrowRight"
+            @click="helpPanelCollapsed = !helpPanelCollapsed"
+          />
         </div>
-      </template>
-
-      <div v-if="result.error" style="color: #f56c6c; margin-bottom: 12px; white-space: pre-wrap">
-        {{ result.error }}
+        <div v-if="!helpPanelCollapsed" class="help-panel-content">
+          <template v-if="activeInput === 'command'">
+            <h4>命令清单</h4>
+            <el-input
+              v-model="commandSearch"
+              placeholder="搜索命令..."
+              clearable
+              size="small"
+              style="margin-bottom: 12px"
+            />
+            <div class="command-list">
+              <div
+                v-for="cmd in filteredCommands"
+                :key="cmd.name"
+                class="command-item"
+                @click="selectCommand(cmd.name)"
+              >
+                <div class="cmd-title">{{ cmd.name }}</div>
+                <div class="cmd-brief">{{ cmd.description }}</div>
+              </div>
+            </div>
+          </template>
+          <template v-else>
+            <h4>{{ form.command || '命令' }} 参数说明</h4>
+            <div v-if="currentCommandInfo" class="param-help">
+              <div class="param-section">
+                <div class="section-title">参数</div>
+                <pre class="param-text">{{ currentCommandInfo.params }}</pre>
+              </div>
+              <div class="param-section">
+                <div class="section-title">示例</div>
+                <div class="example-list">
+                  <div
+                    v-for="(example, idx) in currentCommandInfo.examples"
+                    :key="idx"
+                    class="example-item"
+                    @click="applyExample(example)"
+                  >
+                    <code>{{ example }}</code>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <el-empty v-else description="请先选择一个命令" :image-size="60" />
+          </template>
+        </div>
       </div>
-
-      <div v-for="(r, i) in result.structuredResults" :key="i">
-        <component :is="getRenderer(r.type)" :data="r.data" />
-      </div>
-
-      <div
-        v-if="result.results && result.results.length > 0 && !result.structuredResults"
-        v-for="(r, i) in result.results"
-        :key="'raw-' + i"
-      >
-        <pre
-          style="
-            background: #f5f7fa;
-            padding: 12px;
-            border-radius: 4px;
-            font-size: 13px;
-            line-height: 1.6;
-            overflow-x: auto;
-          "
-          >{{ r }}</pre
-        >
-      </div>
-
-      <div v-if="result.rawResponse && expandRaw" style="margin-top: 12px">
-        <div style="font-weight: 500; margin-bottom: 8px; color: #606266">原始响应</div>
-        <pre
-          style="
-            background: #f5f7fa;
-            padding: 12px;
-            border-radius: 4px;
-            font-size: 12px;
-            max-height: 300px;
-            overflow: auto;
-          "
-          >{{ result.rawResponse }}</pre
-        >
-      </div>
-    </el-card>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch, nextTick } from 'vue';
 import { useServerStore } from '../stores/servers';
 import { useUserStore } from '../stores/user';
+import { useCommandCacheStore } from '../stores/commandCache';
 import { executeCommand } from '../api';
 import { getRenderer } from '../components/ResultRenderer';
+import { ElMessage } from 'element-plus';
+import { CopyDocument, ArrowLeft, ArrowRight } from '@element-plus/icons-vue';
+import arthasCommands from '../data/arthas-commands.json';
 
-const store = useServerStore();
+const STORAGE_KEY = 'zhenduanqi_selected_server';
+
+const serverStore = useServerStore();
 const userStore = useUserStore();
+const commandCacheStore = useCommandCacheStore();
+
 const result = ref(null);
 const executing = ref(false);
 const expandRaw = ref(false);
-const form = ref({ serverId: '', command: '' });
+const form = ref({ serverId: '', command: '', params: '' });
+const activeInput = ref('command');
+const helpPanelCollapsed = ref(false);
+const commandSearch = ref('');
+const commandInputRef = ref(null);
+const paramInputRef = ref(null);
+const commandHistoryIndex = ref(-1);
+const paramHistoryIndex = ref(-1);
 
 const isSuccess = computed(() => result.value?.state === 'succeeded');
 
-onMounted(() => {
-  store.fetchServers();
+const previewCommand = computed(() => {
+  if (!form.value.command.trim()) return '';
+  const cmd = form.value.command.trim();
+  const params = form.value.params.trim();
+  return params ? `${cmd} ${params}` : cmd;
 });
 
+const currentCommandInfo = computed(() => {
+  if (!form.value.command) return null;
+  return arthasCommands.find((c) => c.name.toLowerCase() === form.value.command.toLowerCase());
+});
+
+const filteredCommands = computed(() => {
+  if (!commandSearch.value) return arthasCommands;
+  const keyword = commandSearch.value.toLowerCase();
+  return arthasCommands.filter(
+    (c) => c.name.toLowerCase().includes(keyword) || c.description.toLowerCase().includes(keyword)
+  );
+});
+
+onMounted(() => {
+  serverStore.fetchServers();
+  restoreSelectedServer();
+});
+
+watch(
+  () => form.value.command,
+  (newCmd) => {
+    if (newCmd) {
+      const latestParam = commandCacheStore.getLatestParam(newCmd);
+      if (latestParam && !form.value.params) {
+        form.value.params = latestParam;
+      }
+    }
+  }
+);
+
+function restoreSelectedServer() {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved && serverStore.list.some((s) => s.id === saved)) {
+    form.value.serverId = saved;
+  }
+}
+
+function handleServerChange(serverId) {
+  localStorage.setItem(STORAGE_KEY, serverId);
+}
+
+function filterCommands(queryString, cb) {
+  const results = queryString
+    ? arthasCommands.filter(
+        (c) =>
+          c.name.toLowerCase().includes(queryString.toLowerCase()) ||
+          c.description.toLowerCase().includes(queryString.toLowerCase())
+      )
+    : arthasCommands;
+  cb(results);
+}
+
+function handleCommandSelect(item) {
+  form.value.command = item.name;
+  const latestParam = commandCacheStore.getLatestParam(item.name);
+  if (latestParam) {
+    form.value.params = latestParam;
+  }
+  nextTick(() => {
+    paramInputRef.value?.focus();
+  });
+}
+
+function handleCommandEnter() {
+  if (form.value.command) {
+    paramInputRef.value?.focus();
+  }
+}
+
+function navigateCommandHistory(direction) {
+  const history = commandCacheStore.getCommandHistory();
+  if (history.length === 0) return;
+
+  if (direction === -1) {
+    if (commandHistoryIndex.value < history.length - 1) {
+      commandHistoryIndex.value++;
+    }
+  } else {
+    if (commandHistoryIndex.value > 0) {
+      commandHistoryIndex.value--;
+    } else if (commandHistoryIndex.value === 0) {
+      commandHistoryIndex.value = -1;
+      form.value.command = '';
+      return;
+    }
+  }
+
+  if (commandHistoryIndex.value >= 0 && commandHistoryIndex.value < history.length) {
+    form.value.command = history[commandHistoryIndex.value];
+  }
+}
+
+function navigateParamHistory(direction) {
+  if (!form.value.command) return;
+
+  const history = commandCacheStore.getParamHistory(form.value.command);
+  if (history.length === 0) return;
+
+  if (direction === -1) {
+    if (paramHistoryIndex.value < history.length - 1) {
+      paramHistoryIndex.value++;
+    }
+  } else {
+    if (paramHistoryIndex.value > 0) {
+      paramHistoryIndex.value--;
+    } else if (paramHistoryIndex.value === 0) {
+      paramHistoryIndex.value = -1;
+      form.value.params = '';
+      return;
+    }
+  }
+
+  if (paramHistoryIndex.value >= 0 && paramHistoryIndex.value < history.length) {
+    form.value.params = history[paramHistoryIndex.value];
+  }
+}
+
+function selectCommand(name) {
+  form.value.command = name;
+  const latestParam = commandCacheStore.getLatestParam(name);
+  if (latestParam) {
+    form.value.params = latestParam;
+  }
+  commandInputRef.value?.focus();
+}
+
+function applyExample(example) {
+  const parts = example.split(/\s+/);
+  if (parts.length > 0) {
+    form.value.command = parts[0];
+    form.value.params = parts.slice(1).join(' ');
+  }
+  paramInputRef.value?.focus();
+}
+
 async function handleExecute() {
+  if (!previewCommand.value) return;
+
   executing.value = true;
   expandRaw.value = false;
+
+  commandCacheStore.addCommandToHistory(form.value.command);
+  if (form.value.params.trim()) {
+    commandCacheStore.addParamToHistory(form.value.command, form.value.params);
+  }
+
+  commandHistoryIndex.value = -1;
+  paramHistoryIndex.value = -1;
+
   try {
-    const res = await executeCommand(form.value.serverId, form.value.command);
+    const res = await executeCommand(form.value.serverId, previewCommand.value);
     result.value = res.data;
   } catch (e) {
     result.value = {
@@ -149,4 +429,199 @@ function clearResult() {
   result.value = null;
   expandRaw.value = false;
 }
+
+async function copyCommand() {
+  if (!previewCommand.value) return;
+  try {
+    await navigator.clipboard.writeText(previewCommand.value);
+    ElMessage.success('已复制到剪贴板');
+  } catch {
+    ElMessage.error('复制失败');
+  }
+}
 </script>
+
+<style scoped>
+.diagnose-page {
+  height: 100%;
+}
+
+.main-content {
+  display: flex;
+  gap: 16px;
+  height: calc(100vh - 120px);
+}
+
+.left-panel {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.right-panel {
+  width: 300px;
+  flex-shrink: 0;
+  background: #fff;
+  border-radius: 4px;
+  border: 1px solid #ebeef5;
+  display: flex;
+  flex-direction: column;
+  transition: width 0.3s;
+}
+
+.right-panel.collapsed {
+  width: 40px;
+}
+
+.help-panel-header {
+  padding: 12px;
+  border-bottom: 1px solid #ebeef5;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 500;
+}
+
+.help-panel-content {
+  flex: 1;
+  overflow: auto;
+  padding: 12px;
+}
+
+.command-card {
+  flex-shrink: 0;
+}
+
+.result-card {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.command-input-wrapper {
+  display: flex;
+  gap: 8px;
+}
+
+.command-suggestion {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0;
+}
+
+.cmd-name {
+  font-weight: 500;
+  color: #409eff;
+}
+
+.cmd-desc {
+  font-size: 12px;
+  color: #909399;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.command-preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.preview-code {
+  flex: 1;
+  background: #f5f7fa;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 13px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.command-list {
+  max-height: calc(100vh - 350px);
+  overflow-y: auto;
+}
+
+.command-item {
+  padding: 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.command-item:hover {
+  background: #f5f7fa;
+}
+
+.cmd-title {
+  font-weight: 500;
+  color: #409eff;
+  margin-bottom: 2px;
+}
+
+.cmd-brief {
+  font-size: 12px;
+  color: #606266;
+  line-height: 1.4;
+}
+
+.param-help {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.param-section {
+  margin-bottom: 8px;
+}
+
+.section-title {
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: #303133;
+}
+
+.param-text {
+  background: #f5f7fa;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.example-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.example-item {
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.example-item:hover {
+  background: #ecf5ff;
+}
+
+.example-item code {
+  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  font-size: 12px;
+  color: #409eff;
+}
+
+h4 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: #303133;
+}
+</style>

--- a/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
+++ b/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
@@ -28,6 +28,4 @@ public interface ArthasSessionRepository extends JpaRepository<ArthasSession, Lo
     List<ArthasSession> findByLastActiveAtBeforeAndStatus(LocalDateTime before, String status);
 
     List<ArthasSession> findByCreatedAtBeforeAndStatus(LocalDateTime before, String status);
-
-    List<ArthasSession> findByServerIdAndUsernameAndStatusOrderByCreatedAtDesc(String serverId, String username, String status);
 }

--- a/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
+++ b/src/main/java/com/zhenduanqi/repository/ArthasSessionRepository.java
@@ -28,4 +28,6 @@ public interface ArthasSessionRepository extends JpaRepository<ArthasSession, Lo
     List<ArthasSession> findByLastActiveAtBeforeAndStatus(LocalDateTime before, String status);
 
     List<ArthasSession> findByCreatedAtBeforeAndStatus(LocalDateTime before, String status);
+
+    List<ArthasSession> findByServerIdAndUsernameAndStatusOrderByCreatedAtDesc(String serverId, String username, String status);
 }

--- a/src/test/java/com/zhenduanqi/controller/ArthasSessionControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/ArthasSessionControllerTest.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Closes #185

## 功能实现

### 1. 服务器选择缓存
- ✅ 使用统一的 LocalStorage key（`zhenduanqi_selected_server`）
- ✅ 与诊断工作台页面共享服务器选择状态
- ✅ 刷新页面后自动恢复选中的服务器

### 2. 智能命令输入框
- ✅ 命令框支持手动输入、下拉选择、自动联想
- ✅ 输入时自动触发联想，显示匹配的命令下拉列表
- ✅ 支持键盘上下选择、回车确认
- ✅ 保存最近 100 条命令历史，光标在命令框时按上下键切换历史命令

### 3. 参数输入框
- ✅ 自由输入参数
- ✅ 每个命令保存最近 100 条参数历史
- ✅ 切换命令时，参数框自动显示该命令最近一条参数
- ✅ 光标在参数框时按上下键切换历史参数

### 4. 右侧帮助面板
- ✅ 固定显示在右侧，宽度约 300px
- ✅ 根据光标位置自动切换内容
- ✅ 面板可折叠
- ✅ 光标在命令框时：显示命令清单（46 个可用命令）
- ✅ 光标在参数框时：显示当前命令的参数说明和示例用法

### 5. 指令预览框
- ✅ 放在命令框和参数框下方，独立一行
- ✅ 使用代码块样式展示
- ✅ 只读展示，不可编辑
- ✅ 实时更新
- ✅ 添加"复制命令"按钮

### 6. 命令清单数据
- ✅ 创建 `arthas-commands.json` 包含 46 个常用 Arthas 命令
- ✅ 每个命令包含：命令名、简短描述、参数说明、示例

## 文件变更

- `frontend/src/data/arthas-commands.json` - 新增命令清单数据
- `frontend/src/stores/commandCache.js` - 新增命令历史缓存 store
- `frontend/src/views/Diagnose.vue` - 重构页面实现所有功能
- `.gitignore` - 修复 data/ 规则误匹配问题
- `PRD.md` - 更新项目结构

## 验证情况

- ✅ `npm run build` 构建成功
- ✅ `npm run format` 格式检查通过
- ✅ 功能测试：
  - 服务器选择缓存正常工作
  - 命令联想和选择正常
  - 命令/参数历史记录正常
  - 帮助面板显示和折叠正常
  - 指令预览和复制功能正常