### PR TITLE
[P1] DashboardRenderer GC对比展示和服务器绑定缓存 (#192)

### DIFF
--- a/frontend/src/components/ResultRenderer/DashboardRenderer.vue
+++ b/frontend/src/components/ResultRenderer/DashboardRenderer.vue
@@ -56,12 +56,58 @@
         </el-tab-pane>
 
         <el-tab-pane label="GC">
-          <el-table :data="gcData" stripe size="small">
+          <div class="gc-header">
+            <el-button v-if="hasBaseline" type="warning" size="small" @click="refreshBaseline">
+              刷新基线
+            </el-button>
+            <span v-if="baselineTimestamp" class="baseline-info">
+              基线时间: {{ formatBaselineTime(baselineTimestamp) }}
+            </span>
+          </div>
+          <el-table :data="gcDataWithDelta" stripe size="small">
             <el-table-column prop="name" label="GC收集器" min-width="150" />
-            <el-table-column prop="count" label="次数" width="80" align="center" />
-            <el-table-column prop="time" label="耗时(ms)" width="100" align="right">
+            <el-table-column label="累积次数" width="100" align="center">
+              <template #header>
+                <el-tooltip content="从 JVM 启动到当前的总 GC 次数" placement="top">
+                  <span>累积次数</span>
+                </el-tooltip>
+              </template>
+              <template #default="{ row }">
+                {{ row.count }}
+              </template>
+            </el-table-column>
+            <el-table-column label="本次增量" width="100" align="center">
+              <template #header>
+                <el-tooltip content='与上次采集的差值（首次采集显示"首次"）' placement="top">
+                  <span>本次增量</span>
+                </el-tooltip>
+              </template>
+              <template #default="{ row }">
+                <span v-if="row.countDelta === null" class="first-tag">首次</span>
+                <span v-else-if="row.countDelta === 0" class="delta-zero">+0</span>
+                <span v-else class="delta-positive">+{{ row.countDelta }}</span>
+              </template>
+            </el-table-column>
+            <el-table-column label="累积耗时(ms)" width="120" align="right">
+              <template #header>
+                <el-tooltip content="从 JVM 启动到当前的总 GC 耗时" placement="top">
+                  <span>累积耗时(ms)</span>
+                </el-tooltip>
+              </template>
               <template #default="{ row }">
                 {{ row.time != null ? row.time : '-' }}
+              </template>
+            </el-table-column>
+            <el-table-column label="本次增量" width="100" align="center">
+              <template #header>
+                <el-tooltip content='与上次采集的差值（首次采集显示"首次"）' placement="top">
+                  <span>本次增量</span>
+                </el-tooltip>
+              </template>
+              <template #default="{ row }">
+                <span v-if="row.timeDelta === null" class="first-tag">首次</span>
+                <span v-else-if="row.timeDelta === 0" class="delta-zero">+0</span>
+                <span v-else class="delta-positive">+{{ row.timeDelta }}</span>
               </template>
             </el-table-column>
           </el-table>
@@ -84,13 +130,20 @@
 
 <script setup>
 import { computed } from 'vue';
+import { useDashboardBaselineStore } from '@/stores/dashboardBaseline';
 
 const props = defineProps({
   data: {
     type: Object,
     default: () => ({}),
   },
+  serverId: {
+    type: String,
+    default: null,
+  },
 });
+
+const baselineStore = useDashboardBaselineStore();
 
 const defaultData = {
   threads: [
@@ -116,6 +169,11 @@ const defaultData = {
   ],
 };
 
+const defaultGcData = [
+  { name: 'PS Scavenge', count: 15, time: 120 },
+  { name: 'PS MarkSweep', count: 3, time: 80 },
+];
+
 const currentData = computed(() => {
   if (!props.data || Object.keys(props.data).length === 0) {
     return defaultData;
@@ -138,6 +196,52 @@ const isExample = computed(() => {
   return !props.data || Object.keys(props.data).length === 0;
 });
 
+const hasBaseline = computed(() => {
+  return baselineStore.getBaseline(props.serverId) !== null;
+});
+
+const baselineTimestamp = computed(() => {
+  const baseline = baselineStore.getBaseline(props.serverId);
+  return baseline?.timestamp || null;
+});
+
+const currentGcData = computed(() => {
+  const data = currentData.value;
+  if (data?.gcInfos) {
+    return normalizeGcInfos(data.gcInfos);
+  }
+  if (data?.gc) {
+    return normalizeGcData(data.gc);
+  }
+  return [];
+});
+
+const gcDataWithDelta = computed(() => {
+  const currentGc = currentGcData.value;
+  if (!currentGc.length) return [];
+
+  const baseline = baselineStore.getBaseline(props.serverId);
+  if (!baseline || !baseline.gc) {
+    baselineStore.setBaseline(props.serverId, currentGc);
+    return currentGc.map((item) => ({
+      ...item,
+      countDelta: null,
+      timeDelta: null,
+    }));
+  }
+
+  const deltaData = baselineStore.calculateDelta(currentGc, baseline.gc);
+  if (!deltaData) {
+    return currentGc.map((item) => ({
+      ...item,
+      countDelta: null,
+      timeDelta: null,
+    }));
+  }
+
+  return deltaData;
+});
+
 const threadData = computed(() => {
   if (currentData.value?.threads) {
     return currentData.value.threads.map(normalizeThread);
@@ -156,16 +260,12 @@ const memoryData = computed(() => {
   return [];
 });
 
-const gcData = computed(() => {
-  const data = currentData.value;
-  if (data?.gcInfos) {
-    return normalizeGcInfos(data.gcInfos);
+function refreshBaseline() {
+  const currentGc = currentGcData.value;
+  if (currentGc.length) {
+    baselineStore.setBaseline(props.serverId, currentGc);
   }
-  if (data?.gc) {
-    return normalizeGcData(data.gc);
-  }
-  return [];
-});
+}
 
 function normalizeThread(thread) {
   return {
@@ -286,6 +386,19 @@ function getStatusType(status) {
   if (status === 'WAITING' || status === 'TIMED_WAITING') return 'warning';
   return 'info';
 }
+
+function formatBaselineTime(timestamp) {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  return date.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
 </script>
 
 <style scoped>
@@ -299,5 +412,30 @@ function getStatusType(status) {
 
 .dashboard-empty {
   padding: 20px;
+}
+
+.gc-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.baseline-info {
+  font-size: 12px;
+  color: #909399;
+}
+
+.first-tag {
+  color: #909399;
+  font-style: italic;
+}
+
+.delta-zero {
+  color: #67c23a;
+}
+
+.delta-positive {
+  color: #e6a23c;
 }
 </style>

--- a/frontend/src/components/ResultRenderer/DashboardRenderer.vue
+++ b/frontend/src/components/ResultRenderer/DashboardRenderer.vue
@@ -130,7 +130,7 @@
 
 <script setup>
 import { computed } from 'vue';
-import { useDashboardBaselineStore } from '@/stores/dashboardBaseline';
+import { useDashboardBaselineStore } from '../../stores/dashboardBaseline';
 
 const props = defineProps({
   data: {

--- a/frontend/src/stores/dashboardBaseline.js
+++ b/frontend/src/stores/dashboardBaseline.js
@@ -1,0 +1,96 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+const STORAGE_KEY = 'zhenduanqi_dashboard_baselines';
+
+export const useDashboardBaselineStore = defineStore('dashboardBaseline', () => {
+  const baselines = ref({});
+
+  function loadFromStorage() {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        baselines.value = JSON.parse(saved);
+      }
+    } catch (e) {
+      console.warn('Failed to load dashboard baselines from storage:', e);
+      baselines.value = {};
+    }
+  }
+
+  function saveToStorage() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(baselines.value));
+    } catch (e) {
+      console.warn('Failed to save dashboard baselines to storage:', e);
+    }
+  }
+
+  function getBaseline(serverId) {
+    if (!serverId) return null;
+    return baselines.value[serverId] || null;
+  }
+
+  function setBaseline(serverId, gcData) {
+    if (!serverId) return;
+    baselines.value[serverId] = {
+      timestamp: new Date().toISOString(),
+      gc: gcData,
+    };
+    saveToStorage();
+  }
+
+  function clearBaseline(serverId) {
+    if (!serverId) return;
+    delete baselines.value[serverId];
+    saveToStorage();
+  }
+
+  function clearAllBaselines() {
+    baselines.value = {};
+    saveToStorage();
+  }
+
+  function calculateDelta(currentGc, baselineGc) {
+    if (!baselineGc || !currentGc) return null;
+
+    const result = [];
+    const baselineMap = {};
+
+    baselineGc.forEach((item) => {
+      baselineMap[item.name] = item;
+    });
+
+    currentGc.forEach((item) => {
+      const baseline = baselineMap[item.name];
+      if (baseline) {
+        result.push({
+          ...item,
+          countDelta: item.count - baseline.count,
+          timeDelta: item.time - baseline.time,
+        });
+      } else {
+        result.push({
+          ...item,
+          countDelta: null,
+          timeDelta: null,
+        });
+      }
+    });
+
+    return result;
+  }
+
+  loadFromStorage();
+
+  return {
+    baselines,
+    getBaseline,
+    setBaseline,
+    clearBaseline,
+    clearAllBaselines,
+    calculateDelta,
+    loadFromStorage,
+    saveToStorage,
+  };
+});

--- a/frontend/src/views/DiagnoseWorkbench.vue
+++ b/frontend/src/views/DiagnoseWorkbench.vue
@@ -62,7 +62,7 @@
         </div>
       </div>
       <el-card v-loading="dashboardLoading" class="dashboard-card">
-        <DashboardRenderer :data="dashboardData" />
+        <DashboardRenderer :data="dashboardData" :server-id="selectedServerId" />
         <div
           v-if="!dashboardData"
           style="margin-top: 8px; font-size: 11px; color: #909399; font-style: italic"

--- a/frontend/src/views/SceneDiagnose.vue
+++ b/frontend/src/views/SceneDiagnose.vue
@@ -152,7 +152,13 @@
             </div>
 
             <div v-for="(r, i) in stepStates[index]?.result.structuredResults" :key="i">
-              <component :is="getRenderer(r.type)" :data="r.data" />
+              <component
+                v-if="r.type === 'dashboard'"
+                :is="getRenderer(r.type)"
+                :data="r.data"
+                :server-id="diagnoseStore.selectedServerId"
+              />
+              <component v-else :is="getRenderer(r.type)" :data="r.data" />
             </div>
 
             <div


### PR DESCRIPTION
## 实现内容

### 1. GC Tab 表格优化
- 添加了累积次数、本次增量、累积耗时、本次增量列
- 使用 Tooltip 显示列的详细说明
- 首次采集显示首次，无变化显示+0，有变化显示+N并用颜色区分

### 2. 缓存方案优化
- 创建了  store，使用 LocalStorage key 
- 基线数据与服务器 ID 绑定，不同服务器切换时基线数据不会混淆
- 添加了刷新基线按钮，用户可以手动刷新基线

### 3. 已知问题核实
- GC 数据的字段名： 和 
- 线程数据的字段名：uid=501(huyongsheng) gid=20(staff) groups=20(staff),101(access_bpf),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),701(com.apple.sharepoint.group.1),33(_appstore),98(_lpadmin),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae) 和 
- 内存数据的字段名： 和 

### 修改的文件
-  - 核心组件
-  - 新增的 store
-  - 传递 serverId prop
-  - 传递 serverId prop

Closes #192