### PR TITLE
[P1] test(scene): 更新场景相关测试用例 (#179)

### DIFF
--- a/frontend/e2e/scene-diagnosis-workbench.spec.py
+++ b/frontend/e2e/scene-diagnosis-workbench.spec.py
@@ -1,0 +1,146 @@
+from playwright.sync_api import sync_playwright
+import time
+
+
+def test_diagnosis_workbench():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context()
+        page = context.new_page()
+
+        page.goto('http://localhost:5173')
+        page.wait_for_load_state('networkidle')
+        time.sleep(1)
+
+        page.screenshot(path='/tmp/workbench-01-login.png', full_page=True)
+
+        page.fill('input[type="text"]', 'admin')
+        page.fill('input[type="password"]', 'admin123')
+        page.click('button:has-text("登录")')
+
+        page.wait_for_load_state('networkidle')
+        time.sleep(1)
+
+        page.goto('http://localhost:5173/#/')
+        page.wait_for_load_state('networkidle')
+        time.sleep(1)
+
+        page.screenshot(path='/tmp/workbench-02-page.png', full_page=True)
+
+        header = page.locator('.workbench-header h2')
+        assert header.count() > 0, 'Page should show diagnosis workbench header'
+        assert header.text_content() == '诊断工作台', 'Header should be "诊断工作台"'
+
+        dashboard_section = page.locator('.dashboard-section')
+        assert dashboard_section.count() > 0, 'Dashboard section should exist'
+
+        dashboard_header = dashboard_section.locator('h3')
+        assert dashboard_header.text_content() == '实时监控', 'Dashboard header should be "实时监控"'
+
+        server_select = page.locator('.header-right .el-select')
+        assert server_select.count() > 0, 'Server selector should exist'
+
+        server_select.click()
+        time.sleep(0.5)
+
+        page.screenshot(path='/tmp/workbench-03-server-dropdown.png', full_page=True)
+
+        options = page.locator('.el-select-dropdown__item')
+        if options.count() > 0:
+            options.first.click()
+            time.sleep(0.5)
+
+            saved_server = page.evaluate('localStorage.getItem("selectedServerId")')
+            print(f'Server saved to localStorage: {saved_server}')
+            assert saved_server, 'Server should be saved to localStorage'
+
+        page.screenshot(path='/tmp/workbench-04-server-selected.png', full_page=True)
+
+        refresh_input = page.locator('.dashboard-controls .el-input-number input')
+        assert refresh_input.count() > 0, 'Refresh interval input should exist'
+
+        start_button = page.locator('button:has-text("开始刷新")')
+        manual_refresh_button = page.locator('button:has-text("立即刷新")')
+        assert start_button.count() > 0 or manual_refresh_button.count() > 0, \
+            'Refresh buttons should exist'
+
+        page.screenshot(path='/tmp/workbench-05-dashboard-controls.png', full_page=True)
+
+        category_tags = page.locator('.category-tags .el-tag')
+        category_count = category_tags.count()
+        print(f'Found {category_count} category tags')
+        assert category_count >= 6, f'Should have at least 6 category tags, found {category_count}'
+
+        expected_categories = ['接口响应慢', 'CPU 高', '内存高', 'GC 频繁', '线程池高', '类加载异常']
+        tag_texts = [tag.text_content() for tag in category_tags.all()]
+        for cat in expected_categories:
+            assert any(cat in text for text in tag_texts), f'Category "{cat}" should be present'
+
+        page.screenshot(path='/tmp/workbench-06-categories.png', full_page=True)
+
+        search_input = page.locator('.scene-filter-section .el-input input')
+        assert search_input.count() > 0, 'Search input should exist'
+
+        search_input.fill('CPU')
+        time.sleep(0.5)
+
+        page.screenshot(path='/tmp/workbench-07-search.png', full_page=True)
+
+        visible_scenes = page.locator('.el-collapse-item')
+        visible_count = visible_scenes.count()
+        print(f'Found {visible_count} scenes after search')
+
+        search_input.fill('')
+        time.sleep(0.5)
+
+        category_tags.first.click()
+        time.sleep(0.5)
+
+        page.screenshot(path='/tmp/workbench-08-filtered.png', full_page=True)
+
+        clear_filter = page.locator('.el-tag:has-text("清除筛选")')
+        if clear_filter.count() > 0:
+            clear_filter.click()
+            time.sleep(0.5)
+
+        scene_items = page.locator('.el-collapse-item')
+        scene_count = scene_items.count()
+        print(f'Found {scene_count} scenes')
+        assert scene_count >= 6, f'Should have at least 6 scenes, found {scene_count}'
+
+        page.screenshot(path='/tmp/workbench-09-scenes.png', full_page=True)
+
+        if scene_items.count() > 0:
+            scene_items.first.click()
+            time.sleep(1)
+
+            page.screenshot(path='/tmp/workbench-10-scene-expanded.png', full_page=True)
+
+            step_cards = page.locator('.step-card')
+            step_count = step_cards.count()
+            print(f'Found {step_count} steps in first scene')
+            assert step_count > 0, 'Scene should have at least one step'
+
+            step_title = page.locator('.step-title').first
+            assert step_title.count() > 0, 'Step should have a title'
+
+            command_input = page.locator('.step-content .el-input input').first
+            assert command_input.count() > 0, 'Step should have command input'
+
+        page.screenshot(path='/tmp/workbench-11-final.png', full_page=True)
+
+        print('\n=== Test Results ===')
+        print('✓ Diagnosis workbench page loads correctly')
+        print('✓ Dashboard section displays')
+        print('✓ Server selector exists and saves selection')
+        print('✓ Refresh controls exist')
+        print(f'✓ Category tags display correctly ({category_count} found)')
+        print('✓ Search functionality works')
+        print(f'✓ Scene list displays ({scene_count} scenes)')
+        print('✓ Scene expansion shows steps')
+
+        browser.close()
+
+
+if __name__ == '__main__':
+    test_diagnosis_workbench()

--- a/src/test/java/com/zhenduanqi/controller/SceneControllerTest.java
+++ b/src/test/java/com/zhenduanqi/controller/SceneControllerTest.java
@@ -64,13 +64,14 @@ class SceneControllerTest {
     void getScenes_withValidData_returnsScenes() throws Exception {
         DiagnoseScene scene = new DiagnoseScene();
         scene.setId(1L);
-        scene.setName("CPU 问题诊断");
-        scene.setDescription("诊断 CPU 使用率过高的问题");
+        scene.setName("接口响应慢排查");
+        scene.setDescription("排查接口响应时间长、超时等问题");
+        scene.setCategory("SLOW_RESPONSE");
 
         SceneStep step = new SceneStep();
         step.setId(1L);
-        step.setTitle("检查 CPU");
-        step.setCommand("top -n 1");
+        step.setTitle("查看 JVM 概览");
+        step.setCommand("dashboard -n 1");
         step.setStepOrder(1);
 
         scene.setSteps(Arrays.asList(step));
@@ -80,33 +81,36 @@ class SceneControllerTest {
         mockMvc.perform(get("/api/scenes").cookie(adminCookie))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
-                .andExpect(jsonPath("$[0].name").value("CPU 问题诊断"))
-                .andExpect(jsonPath("$[0].steps[0].title").value("检查 CPU"))
+                .andExpect(jsonPath("$[0].name").value("接口响应慢排查"))
+                .andExpect(jsonPath("$[0].category").value("SLOW_RESPONSE"))
+                .andExpect(jsonPath("$[0].steps[0].title").value("查看 JVM 概览"))
                 .andExpect(jsonPath("$[0].steps[0].scene").doesNotExist());
     }
 
     @Test
     void getScene_withValidId_returnsSceneWithSteps() throws Exception {
         DiagnoseScene scene = new DiagnoseScene();
-        scene.setId(1L);
-        scene.setName("内存问题诊断");
+        scene.setId(2L);
+        scene.setName("CPU 飙高排查");
+        scene.setCategory("CPU_HIGH");
 
         SceneStep step = new SceneStep();
         step.setId(1L);
-        step.setTitle("检查内存");
-        step.setCommand("free -m");
+        step.setTitle("查看 JVM 概览");
+        step.setCommand("dashboard -n 1");
         step.setStepOrder(1);
         step.setScene(scene);
 
         scene.setSteps(Arrays.asList(step));
 
-        when(sceneService.getSceneById(1L)).thenReturn(Optional.of(scene));
+        when(sceneService.getSceneById(2L)).thenReturn(Optional.of(scene));
 
-        mockMvc.perform(get("/api/scenes/1").cookie(adminCookie))
+        mockMvc.perform(get("/api/scenes/2").cookie(adminCookie))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1))
-                .andExpect(jsonPath("$.name").value("内存问题诊断"))
-                .andExpect(jsonPath("$.steps[0].title").value("检查内存"))
+                .andExpect(jsonPath("$.id").value(2))
+                .andExpect(jsonPath("$.name").value("CPU 飙高排查"))
+                .andExpect(jsonPath("$.category").value("CPU_HIGH"))
+                .andExpect(jsonPath("$.steps[0].title").value("查看 JVM 概览"))
                 .andExpect(jsonPath("$.steps[0].scene").doesNotExist());
     }
 }

--- a/src/test/java/com/zhenduanqi/e2e/SceneE2ETest.java
+++ b/src/test/java/com/zhenduanqi/e2e/SceneE2ETest.java
@@ -58,34 +58,122 @@ class SceneE2ETest {
     }
 
     @Test
-    void scene6_shouldHaveCorrectStepConfiguration() throws Exception {
-        DiagnoseScene scene6 = new DiagnoseScene();
-        scene6.setId(6L);
-        scene6.setName("方法耗时追踪");
-        scene6.setCategory("METHOD");
+    void scene1_shouldHaveCorrectStepConfiguration() throws Exception {
+        DiagnoseScene scene1 = new DiagnoseScene();
+        scene1.setId(1L);
+        scene1.setName("接口响应慢排查");
+        scene1.setCategory("SLOW_RESPONSE");
 
         SceneStep step1 = new SceneStep();
         step1.setId(1L);
-        step1.setTitle("确认类已加载");
-        step1.setCommand("sc -d {className}");
+        step1.setTitle("查看 JVM 概览");
+        step1.setCommand("dashboard -n 1");
         step1.setContinuous(false);
-        step1.setMaxExecTime(10000);
+        step1.setMaxExecTime(15000);
+        step1.setScene(scene1);
+
+        SceneStep step2 = new SceneStep();
+        step2.setId(2L);
+        step2.setTitle("确认类已加载");
+        step2.setCommand("sc -d {className}");
+        step2.setContinuous(false);
+        step2.setMaxExecTime(10000);
+        step2.setScene(scene1);
+
+        SceneStep step3 = new SceneStep();
+        step3.setId(3L);
+        step3.setTitle("追踪方法调用路径");
+        step3.setCommand("trace {className} {methodName} -n 5");
+        step3.setContinuous(true);
+        step3.setMaxExecTime(30000);
+        step3.setScene(scene1);
+
+        SceneStep step4 = new SceneStep();
+        step4.setId(4L);
+        step4.setTitle("观察方法入参和返回值");
+        step4.setCommand("watch {className} {methodName} '{params, returnObj, throwExp}' -n 5 -x 2");
+        step4.setContinuous(true);
+        step4.setMaxExecTime(30000);
+        step4.setScene(scene1);
+
+        scene1.setSteps(Arrays.asList(step1, step2, step3, step4));
+
+        when(sceneService.getAllScenes()).thenReturn(Arrays.asList(scene1));
+
+        mockMvc.perform(get("/api/scenes").cookie(adminCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("接口响应慢排查"))
+                .andExpect(jsonPath("$[0].category").value("SLOW_RESPONSE"))
+                .andExpect(jsonPath("$[0].steps[0].continuous").value(false))
+                .andExpect(jsonPath("$[0].steps[2].continuous").value(true))
+                .andExpect(jsonPath("$[0].steps[3].continuous").value(true))
+                .andExpect(jsonPath("$[0].steps[2].maxExecTime").value(30000))
+                .andExpect(jsonPath("$[0].steps[3].maxExecTime").value(30000));
+    }
+
+    @Test
+    void scene2_shouldHaveCorrectStepConfiguration() throws Exception {
+        DiagnoseScene scene2 = new DiagnoseScene();
+        scene2.setId(2L);
+        scene2.setName("CPU 飙高排查");
+        scene2.setCategory("CPU_HIGH");
+
+        SceneStep step1 = new SceneStep();
+        step1.setId(1L);
+        step1.setContinuous(false);
+        step1.setMaxExecTime(15000);
+        step1.setScene(scene2);
+
+        SceneStep step2 = new SceneStep();
+        step2.setId(2L);
+        step2.setContinuous(false);
+        step2.setMaxExecTime(10000);
+        step2.setScene(scene2);
+
+        SceneStep step3 = new SceneStep();
+        step3.setId(3L);
+        step3.setContinuous(false);
+        step3.setMaxExecTime(10000);
+        step3.setScene(scene2);
+
+        SceneStep step4 = new SceneStep();
+        step4.setId(4L);
+        step4.setContinuous(false);
+        step4.setMaxExecTime(10000);
+        step4.setScene(scene2);
+
+        scene2.setSteps(Arrays.asList(step1, step2, step3, step4));
+
+        when(sceneService.getAllScenes()).thenReturn(Arrays.asList(scene2));
+
+        mockMvc.perform(get("/api/scenes").cookie(adminCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("CPU 飙高排查"))
+                .andExpect(jsonPath("$[0].category").value("CPU_HIGH"))
+                .andExpect(jsonPath("$[0].steps[0].continuous").value(false))
+                .andExpect(jsonPath("$[0].steps[1].continuous").value(false));
+    }
+
+    @Test
+    void scene6_shouldHaveAllSyncSteps() throws Exception {
+        DiagnoseScene scene6 = new DiagnoseScene();
+        scene6.setId(6L);
+        scene6.setName("类加载异常排查");
+        scene6.setCategory("CLASS_LOAD_ERROR");
+
+        SceneStep step1 = new SceneStep();
+        step1.setId(1L);
+        step1.setContinuous(false);
         step1.setScene(scene6);
 
         SceneStep step2 = new SceneStep();
         step2.setId(2L);
-        step2.setTitle("追踪方法调用路径");
-        step2.setCommand("trace {className} {methodName} -n 5");
-        step2.setContinuous(true);
-        step2.setMaxExecTime(30000);
+        step2.setContinuous(false);
         step2.setScene(scene6);
 
         SceneStep step3 = new SceneStep();
         step3.setId(3L);
-        step3.setTitle("观察方法入参和返回值");
-        step3.setCommand("watch {className} {methodName} '{params, returnObj, throwExp}' -n 5 -x 2");
-        step3.setContinuous(true);
-        step3.setMaxExecTime(30000);
+        step3.setContinuous(false);
         step3.setScene(scene6);
 
         scene6.setSteps(Arrays.asList(step1, step2, step3));
@@ -94,80 +182,8 @@ class SceneE2ETest {
 
         mockMvc.perform(get("/api/scenes").cookie(adminCookie))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("方法耗时追踪"))
-                .andExpect(jsonPath("$[0].category").value("METHOD"))
-                .andExpect(jsonPath("$[0].steps[0].continuous").value(false))
-                .andExpect(jsonPath("$[0].steps[1].continuous").value(true))
-                .andExpect(jsonPath("$[0].steps[2].continuous").value(true))
-                .andExpect(jsonPath("$[0].steps[1].maxExecTime").value(30000))
-                .andExpect(jsonPath("$[0].steps[2].maxExecTime").value(30000));
-    }
-
-    @Test
-    void scene7_shouldHaveCorrectStepConfiguration() throws Exception {
-        DiagnoseScene scene7 = new DiagnoseScene();
-        scene7.setId(7L);
-        scene7.setName("方法调用监控");
-        scene7.setCategory("METHOD");
-
-        SceneStep step1 = new SceneStep();
-        step1.setId(1L);
-        step1.setContinuous(false);
-        step1.setMaxExecTime(10000);
-        step1.setScene(scene7);
-
-        SceneStep step2 = new SceneStep();
-        step2.setId(2L);
-        step2.setContinuous(true);
-        step2.setMaxExecTime(60000);
-        step2.setScene(scene7);
-
-        SceneStep step3 = new SceneStep();
-        step3.setId(3L);
-        step3.setContinuous(true);
-        step3.setMaxExecTime(30000);
-        step3.setScene(scene7);
-
-        scene7.setSteps(Arrays.asList(step1, step2, step3));
-
-        when(sceneService.getAllScenes()).thenReturn(Arrays.asList(scene7));
-
-        mockMvc.perform(get("/api/scenes").cookie(adminCookie))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("方法调用监控"))
-                .andExpect(jsonPath("$[0].steps[1].continuous").value(true))
-                .andExpect(jsonPath("$[0].steps[1].maxExecTime").value(60000));
-    }
-
-    @Test
-    void scene8_shouldHaveAllSyncSteps() throws Exception {
-        DiagnoseScene scene8 = new DiagnoseScene();
-        scene8.setId(8L);
-        scene8.setName("类冲突排查");
-        scene8.setCategory("CLASSLOADER");
-
-        SceneStep step1 = new SceneStep();
-        step1.setId(1L);
-        step1.setContinuous(false);
-        step1.setScene(scene8);
-
-        SceneStep step2 = new SceneStep();
-        step2.setId(2L);
-        step2.setContinuous(false);
-        step2.setScene(scene8);
-
-        SceneStep step3 = new SceneStep();
-        step3.setId(3L);
-        step3.setContinuous(false);
-        step3.setScene(scene8);
-
-        scene8.setSteps(Arrays.asList(step1, step2, step3));
-
-        when(sceneService.getAllScenes()).thenReturn(Arrays.asList(scene8));
-
-        mockMvc.perform(get("/api/scenes").cookie(adminCookie))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("类冲突排查"))
+                .andExpect(jsonPath("$[0].name").value("类加载异常排查"))
+                .andExpect(jsonPath("$[0].category").value("CLASS_LOAD_ERROR"))
                 .andExpect(jsonPath("$[0].steps[0].continuous").value(false))
                 .andExpect(jsonPath("$[0].steps[1].continuous").value(false))
                 .andExpect(jsonPath("$[0].steps[2].continuous").value(false));
@@ -177,23 +193,23 @@ class SceneE2ETest {
     void scene4_shouldHaveCorrectConfiguration() throws Exception {
         DiagnoseScene scene4 = new DiagnoseScene();
         scene4.setId(4L);
-        scene4.setName("GC 概况诊断");
-        scene4.setCategory("MEMORY");
+        scene4.setName("GC 频繁排查");
+        scene4.setCategory("GC_FREQUENT");
 
         SceneStep step1 = new SceneStep();
         step1.setId(1L);
-        step1.setTitle("查看内存区");
-        step1.setCommand("memory");
+        step1.setTitle("查看 JVM 概览");
+        step1.setCommand("dashboard -n 1");
         step1.setContinuous(false);
-        step1.setMaxExecTime(10000);
+        step1.setMaxExecTime(15000);
         step1.setScene(scene4);
 
         SceneStep step2 = new SceneStep();
         step2.setId(2L);
-        step2.setTitle("查看各内存池详情");
-        step2.setCommand("vmtool --action getInstances --className java.lang.management.MemoryPoolMXBean");
+        step2.setTitle("查看内存区");
+        step2.setCommand("memory");
         step2.setContinuous(false);
-        step2.setMaxExecTime(15000);
+        step2.setMaxExecTime(10000);
         step2.setScene(scene4);
 
         scene4.setSteps(Arrays.asList(step1, step2));
@@ -202,13 +218,13 @@ class SceneE2ETest {
 
         mockMvc.perform(get("/api/scenes").cookie(adminCookie))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("GC 概况诊断"))
-                .andExpect(jsonPath("$[0].category").value("MEMORY"))
-                .andExpect(jsonPath("$[0].steps[0].command").value("memory"))
+                .andExpect(jsonPath("$[0].name").value("GC 频繁排查"))
+                .andExpect(jsonPath("$[0].category").value("GC_FREQUENT"))
+                .andExpect(jsonPath("$[0].steps[0].command").value("dashboard -n 1"))
                 .andExpect(jsonPath("$[0].steps[0].continuous").value(false))
-                .andExpect(jsonPath("$[0].steps[0].maxExecTime").value(10000))
-                .andExpect(jsonPath("$[0].steps[1].command").value("vmtool --action getInstances --className java.lang.management.MemoryPoolMXBean"))
+                .andExpect(jsonPath("$[0].steps[0].maxExecTime").value(15000))
+                .andExpect(jsonPath("$[0].steps[1].command").value("memory"))
                 .andExpect(jsonPath("$[0].steps[1].continuous").value(false))
-                .andExpect(jsonPath("$[0].steps[1].maxExecTime").value(15000));
+                .andExpect(jsonPath("$[0].steps[1].maxExecTime").value(10000));
     }
 }


### PR DESCRIPTION
Closes #179

## 改动内容

### 后端测试更新
- 更新 `SceneControllerTest.java`：使用新的现象分类（SLOW_RESPONSE, CPU_HIGH）
- 更新 `SceneE2ETest.java`：
  - scene1: 接口响应慢排查 (SLOW_RESPONSE)
  - scene2: CPU 飙高排查 (CPU_HIGH)
  - scene4: GC 频繁排查 (GC_FREQUENT)
  - scene6: 类加载异常排查 (CLASS_LOAD_ERROR)

### 前端 E2E 测试
- 新增 `frontend/e2e/scene-diagnosis-workbench.spec.py`：诊断工作台 Playwright 测试

## 验证情况

### 后端测试
```
mvn test
Tests run: 257, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### 测试覆盖
- [x] 场景相关测试通过
- [x] mvn test 无失败
- [x] 前端 Playwright 测试文件已创建

## Playwright 验证截图

测试文件位于 `frontend/e2e/scene-diagnosis-workbench.spec.py`，运行后会生成截图到 `/tmp/workbench-*.png`。

测试覆盖：
- 诊断工作台页面加载
- Dashboard 区域显示
- 服务器选择器
- 分类标签（6个现象分类）
- 场景搜索功能
- 场景列表展示
- 场景步骤展开