### PR TITLE
[P0] 修复诊断页面执行 trace/monitor 命令时结果无法实时显示 (#224)

### DIFF
--- a/frontend/src/views/DiagnoseWorkbench.vue
+++ b/frontend/src/views/DiagnoseWorkbench.vue
@@ -562,7 +562,7 @@ async function handleExecuteStepAsync(scene, stepIndex) {
 
         if (results && results.length > 0) {
           const statusResult = results.find((r) => r.type === 'status');
-          const isTaskCompleted = statusResult?.statusCode === 0;
+          const isTaskCompleted = statusResult?.data?.statusCode === 0;
 
           if (!sceneStepStates.value[key].result) {
             sceneStepStates.value[key].result = { structuredResults: [], results: [] };

--- a/frontend/src/views/DiagnoseWorkbench.vue
+++ b/frontend/src/views/DiagnoseWorkbench.vue
@@ -562,7 +562,7 @@ async function handleExecuteStepAsync(scene, stepIndex) {
 
         if (results && results.length > 0) {
           const statusResult = results.find((r) => r.type === 'status');
-          const isTaskCompleted = statusResult?.data?.status === 'terminated';
+          const isTaskCompleted = statusResult?.statusCode === 0;
 
           if (!sceneStepStates.value[key].result) {
             sceneStepStates.value[key].result = { structuredResults: [], results: [] };

--- a/frontend/src/views/SceneDiagnose.vue
+++ b/frontend/src/views/SceneDiagnose.vue
@@ -391,7 +391,7 @@ async function handleExecuteAsync(index) {
         if (results && results.length > 0) {
           // Check if task is completed (look for status result)
           const statusResult = results.find((r) => r.type === 'status');
-          const isTaskCompleted = statusResult?.data?.status === 'terminated';
+          const isTaskCompleted = statusResult?.statusCode === 0;
 
           // Append new results
           if (!stepStates.value[index].result) {
@@ -558,7 +558,7 @@ async function recoverSessions() {
 
                 if (results && results.length > 0) {
                   const statusResult = results.find((r) => r.type === 'status');
-                  const isTaskCompleted = statusResult?.data?.status === 'terminated';
+                  const isTaskCompleted = statusResult?.statusCode === 0;
 
                   if (!stepStates.value[i].result) {
                     stepStates.value[i].result = { structuredResults: [], results: [] };

--- a/frontend/src/views/SceneDiagnose.vue
+++ b/frontend/src/views/SceneDiagnose.vue
@@ -391,7 +391,7 @@ async function handleExecuteAsync(index) {
         if (results && results.length > 0) {
           // Check if task is completed (look for status result)
           const statusResult = results.find((r) => r.type === 'status');
-          const isTaskCompleted = statusResult?.statusCode === 0;
+          const isTaskCompleted = statusResult?.data?.statusCode === 0;
 
           // Append new results
           if (!stepStates.value[index].result) {
@@ -558,7 +558,7 @@ async function recoverSessions() {
 
                 if (results && results.length > 0) {
                   const statusResult = results.find((r) => r.type === 'status');
-                  const isTaskCompleted = statusResult?.statusCode === 0;
+                  const isTaskCompleted = statusResult?.data?.statusCode === 0;
 
                   if (!stepStates.value[i].result) {
                     stepStates.value[i].result = { structuredResults: [], results: [] };


### PR DESCRIPTION
Closes #224

**问题描述**
诊断页面执行 trace、monitor 等连续输出命令时，结果无法实时显示。

**根本原因**
前端判断任务完成的逻辑存在错误。根据 Arthas HTTP API 文档， 类型的结果使用  字段（0 表示成功），而不是代码中的 。

**修复方案**
将以下代码：

修改为：


**修改文件**
-  - 2 处
-  - 1 处

**验证情况**
- 前端构建成功