### PR TITLE
[P0] fix(deps): resolve Render deployment ByteBuddy ClassNotFoundException (#231)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,10 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.17</version>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <version>1.14.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary\nFix Render deployment failure caused by ByteBuddy ClassNotFoundException.\n\n## Root Cause\nThe explicit ByteBuddy version (1.14.17) in pom.xml conflicted with Spring Boot dependency management.\n\n## Solution\nRemoved explicit version declarations from ByteBuddy dependencies, using Spring Boot BOM version (1.14.13).\n\n## Changes\n- pom.xml: Removed version from byte-buddy and byte-buddy-agent dependencies\n\n## Verification\n- Local build: SUCCESS\n- ByteBuddy version: 1.14.13 (Spring Boot managed)\n\nCloses #231